### PR TITLE
Enable Azure AD

### DIFF
--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -13,7 +13,11 @@
         view="sign_in"
         redirectTo={`${data.url}/auth/callback`}
         appearance={{ theme: ThemeSupa, style: { input: 'color: #fff' } }}
-        magicLink={true}
+        magicLink={false}
+        providers={['azure']}
+        providerScopes={{
+          azure: 'openid profile email',
+        }}
       />
     </div>
   </div>


### PR DESCRIPTION
Cannot be previewed since it requires the callback to be our production url. Azure does not seem to allow wildcard domains.