### PR TITLE
feat: Do not invalidate on sign in event

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import '../app.pcss';
 
-  import { invalidate, invalidateAll } from '$app/navigation';
+  import { invalidate } from '$app/navigation';
   import { onMount } from 'svelte';
 
   export let data;
@@ -11,10 +11,6 @@
     const { data } = supabase.auth.onAuthStateChange((event, newSession) => {
       if (newSession?.expires_at !== session?.expires_at) {
         invalidate('supabase:auth');
-      }
-
-      if (event === 'SIGNED_IN') {
-        invalidateAll();
       }
     });
 


### PR DESCRIPTION
Right now we invalidate everything on focus, since supabase sends `SIGNED_IN` event on refocus. It should be sufficient to listen to newSession and then only invalidating the auth part.