### PR TITLE
style(frontend): :lipstick: hide some elements on leaderboard on mobile

### DIFF
--- a/frontend/src/lib/components/leaderboard.svelte
+++ b/frontend/src/lib/components/leaderboard.svelte
@@ -14,8 +14,14 @@
         <Table.Row>
           <Table.Head class="w-16">#</Table.Head>
           <Table.Head class="">Player</Table.Head>
-          <Table.Head class="">Wins</Table.Head>
-          <Table.Head class="">Losses</Table.Head>
+          <Table.Head class="">
+            <span class="sm:hidden">W</span>
+            <span class="hidden sm:inline">Wins</span>
+          </Table.Head>
+          <Table.Head class="">
+            <span class="sm:hidden">L</span>
+            <span class="hidden sm:inline">Losses</span>
+          </Table.Head>
           <Table.Head class="text-right">Score</Table.Head>
         </Table.Row>
       </Table.Header>
@@ -25,20 +31,24 @@
             <Table.Cell class="w-16 font-bold">{idx + 1}</Table.Cell>
             <Table.Cell>{name}</Table.Cell>
             <Table.Cell>
-              {wins}
-              {#if winningStreak && winningStreak >= SHOW_STREAK_THRESHOLD}
-                <span class="ml-2 text-xs" title="Winning streak"
-                  >🔥 {winningStreak}</span
-                >
-              {/if}
+              <div class="flex flex-row items-center gap-2">
+                {wins}
+                {#if winningStreak && winningStreak >= SHOW_STREAK_THRESHOLD}
+                  <span class="text-xs" title="Winning streak">
+                    🔥 <span class="hidden sm:inline">{winningStreak}</span>
+                  </span>
+                {/if}
+              </div>
             </Table.Cell>
-            <Table.Cell
-              >{loses}
-              {#if losingStreak && losingStreak >= SHOW_STREAK_THRESHOLD}
-                <span class="ml-2 text-xs" title="Losing streak"
-                  >🌧️ {losingStreak}</span
-                >
-              {/if}
+            <Table.Cell>
+              <div class="flex flex-row items-center gap-2">
+                {loses}
+                {#if losingStreak && losingStreak >= SHOW_STREAK_THRESHOLD}
+                  <span class="text-xs" title="Losing streak">
+                    🌧️ <span class="hidden sm:inline">{losingStreak}</span>
+                  </span>
+                {/if}
+              </div>
             </Table.Cell>
             <Table.Cell class="text-right">{mmr != 0 ? mmr : '🐣'}</Table.Cell>
           </Table.Row>


### PR DESCRIPTION
Now:
<img width="360" alt="image" src="https://github.com/madsthom/mmr-project/assets/5781825/526abbee-3fa2-424e-8475-8736aaffb15b">


Before:
<img width="360" alt="image" src="https://github.com/madsthom/mmr-project/assets/5781825/c2af0e28-a856-47f6-b94f-5a0caf6d3468">
