### PR TITLE
#56 - Added score multiplier to account for match results

### DIFF
--- a/backend/mmr/calc.go
+++ b/backend/mmr/calc.go
@@ -63,8 +63,9 @@ func CalculateNewMMR(team1 *Team, team2 *Team, verbose bool) (Team, Team) {
 	winnerAverageTeam := teamsWithNewSkills[0]
 	loserAverageTeam := teamsWithNewSkills[1]
 
-	winnerDiff := math.Abs(winner.Mu() - winnerAverageTeam.Mu())
-	loserDiff := math.Abs(loser.Mu() - loserAverageTeam.Mu())
+	var scoreMultiplier = 1.0 / (1.0 + float64(loserTeam.Score))
+	winnerDiff := math.Abs((winner.Mu() - winnerAverageTeam.Mu()) * scoreMultiplier)
+	loserDiff := math.Abs((loser.Mu() - loserAverageTeam.Mu()) * scoreMultiplier)
 
 	if verbose {
 		fmt.Printf("Winner: %s\n", winnerAverageTeam)


### PR DESCRIPTION
Added score multiplier to account for match results. 

This multiplier acts as a normalised value based on the score difference.
* Case: 10-0 match = apply 100% mmr diff
* Case: 10-9 match = apply 10% mmr diff

> The mmr diff before multiplier still scales based on team composition and trueskill calculation.

Probably requires a recalculation of entire match history and mmr calculations.