### PR TITLE
Simplify MMR API backend

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -8,10 +8,12 @@ on:
     branches: ["main"]
     paths:
       - "backend-dotnet/**/*"
+      - ".github/workflows/test-api.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "backend-dotnet/**/*"
+      - ".github/workflows/test-api.yml"
 
 jobs:
   build:

--- a/.github/workflows/test-mmr-api.yml
+++ b/.github/workflows/test-mmr-api.yml
@@ -7,13 +7,13 @@ on:
   push:
     branches: ["main"]
     paths:
-      - "backend-dotnet/**/*"
-      - ".github/workflows/deploy-api.yml"
+      - "backend/**/*"
+      - ".github/workflows/test-mmr-api.yml"
   pull_request:
     branches: ["main"]
     paths:
-      - "backend-dotnet/**/*"
-      - ".github/workflows/deploy-api.yml"
+      - "backend/**/*"
+      - ".github/workflows/test-mmr-api.yml"
 
 jobs:
   build:

--- a/backend/config/env.go
+++ b/backend/config/env.go
@@ -7,13 +7,13 @@ import (
 )
 
 type Config struct {
-	DBHost      string `env:"DB_HOST,required"`
-	DBUser      string `env:"DB_USER,required"`
-	DBPassword  string `env:"DB_PASSWORD,required"`
-	DBName      string `env:"DB_NAME,required"`
-	DBPort      int    `env:"DB_PORT" envDefault:"5432"`
-	DBSSLMode   string `env:"DB_SSLMODE" envDefault:"disable"`
-	JWTSecret   string `env:"JWT_SECRET,required"`
+	//DBHost      string `env:"DB_HOST,required"`
+	//DBUser      string `env:"DB_USER,required"`
+	//DBPassword  string `env:"DB_PASSWORD,required"`
+	//DBName      string `env:"DB_NAME,required"`
+	//DBPort      int    `env:"DB_PORT" envDefault:"5432"`
+	//DBSSLMode   string `env:"DB_SSLMODE" envDefault:"disable"`
+	//JWTSecret   string `env:"JWT_SECRET,required"`
 	AdminSecret string `env:"ADMIN_SECRET,required"`
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -6,7 +6,6 @@ import (
 )
 
 import (
-	database "mmr/backend/db"
 	server "mmr/backend/server"
 )
 
@@ -14,6 +13,6 @@ import (
 
 func main() {
 	config.LoadEnv()
-	database.Init()
+	//database.Init()
 	server.Init()
 }

--- a/backend/server/router.go
+++ b/backend/server/router.go
@@ -17,37 +17,37 @@ func NewRouter() *gin.Engine {
 
 	v1 := router.Group("/api/v1")
 	{
-		mg := v1.Group("/mmr", middleware.RequireAuth)
-		{
-			match := new(controllers.MatchController)
-			mg.GET("/matches", match.GetMatches)
-		}
-		p := v1.Group("/profile", middleware.RequireAuth)
-		{
-			profile := new(controllers.ProfileController)
-			p.GET("", profile.GetProfile)
-			p.POST("/claim", profile.ClaimUser)
-		}
-		s := v1.Group("/stats", middleware.RequireAuth)
-		{
-			stats := new(controllers.StatsController)
-			s.GET("/leaderboard", stats.GetLeaderboard)
-			s.GET("/player-history", stats.GetPlayerHistory)
-			s.GET("/time-distribution", stats.GetTimeStatistics)
-		}
-		u := v1.Group("/users")
-		{
-			users := new(controllers.UsersController)
-			u.GET("", users.ListUsers)
-			u.POST("", users.CreateUser)
-			u.GET("/search", users.SearchUsers)
-			u.GET("/:id", users.GetUser)
-		}
-		a := v1.Group("/admin", middleware.RequireAdminAuth)
-		{
-			admin := new(controllers.AdminController)
-			a.POST("/recalculate", admin.RecalculateMatches)
-		}
+		//mg := v1.Group("/mmr", middleware.RequireAuth)
+		//{
+		//	match := new(controllers.MatchController)
+		//	mg.GET("/matches", match.GetMatches)
+		//}
+		//p := v1.Group("/profile", middleware.RequireAuth)
+		//{
+		//	profile := new(controllers.ProfileController)
+		//	p.GET("", profile.GetProfile)
+		//	p.POST("/claim", profile.ClaimUser)
+		//}
+		//s := v1.Group("/stats", middleware.RequireAuth)
+		//{
+		//	stats := new(controllers.StatsController)
+		//	s.GET("/leaderboard", stats.GetLeaderboard)
+		//	s.GET("/player-history", stats.GetPlayerHistory)
+		//	s.GET("/time-distribution", stats.GetTimeStatistics)
+		//}
+		//u := v1.Group("/users")
+		//{
+		//	users := new(controllers.UsersController)
+		//	u.GET("", users.ListUsers)
+		//	u.POST("", users.CreateUser)
+		//	u.GET("/search", users.SearchUsers)
+		//	u.GET("/:id", users.GetUser)
+		//}
+		//a := v1.Group("/admin", middleware.RequireAdminAuth)
+		//{
+		//	admin := new(controllers.AdminController)
+		//	a.POST("/recalculate", admin.RecalculateMatches)
+		//}
 		calc := v1.Group("/mmr-calculation", middleware.RequireAdminAuth)
 		{
 			calculation := new(controllers.CalculationController)
@@ -56,15 +56,15 @@ func NewRouter() *gin.Engine {
 		}
 	}
 
-	v2 := router.Group("/api/v2")
-	{
-		mg := v2.Group("/mmr", middleware.RequireAuth)
-		{
-			match := new(controllers.MatchController)
-			mg.GET("/matches", match.GetMatchesV2)
-			mg.POST("/matches", match.SubmitMatchV2)
-		}
-	}
+	//v2 := router.Group("/api/v2")
+	//{
+	//	mg := v2.Group("/mmr", middleware.RequireAuth)
+	//	{
+	//		match := new(controllers.MatchController)
+	//		mg.GET("/matches", match.GetMatchesV2)
+	//		mg.POST("/matches", match.SubmitMatchV2)
+	//	}
+	//}
 
 	router.GET("/swagger", func(ctx *gin.Context) {
 		ctx.Redirect(http.StatusPermanentRedirect, "/swagger/index.html")


### PR DESCRIPTION
Since we have moved the CRUD to dotnet we no longer need it in Go. So commenting it out for now. Will be removed soon.

Also planning on renaming the folders to accurately describe what they are, i.e.:

- `backend/` becomes `mmr-api/`
- `backend-dotnet/` becomes `api/`