### PR TITLE
Introduce batching calculations

### DIFF
--- a/backend-dotnet/MMRProject.Api/MMRCalculationApi/MMRCalculationApiClient.cs
+++ b/backend-dotnet/MMRProject.Api/MMRCalculationApi/MMRCalculationApiClient.cs
@@ -5,6 +5,7 @@ namespace MMRProject.Api.MMRCalculationApi;
 public interface IMMRCalculationApiClient
 {
     Task<MMRCalculationResponse> CalculateMMRAsync(MMRCalculationRequest request);
+    Task<List<MMRCalculationResponse>> CalculateMMRBatchAsync(List<MMRCalculationRequest> requests);
 }
 
 public class MMRCalculationApiClient(HttpClient httpClient) : IMMRCalculationApiClient
@@ -14,6 +15,20 @@ public class MMRCalculationApiClient(HttpClient httpClient) : IMMRCalculationApi
         var response = await httpClient.PostAsJsonAsync("api/v1/mmr-calculation", request);
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<MMRCalculationResponse>();
+        if (result == null)
+        {
+            // TODO: Better exception
+            throw new Exception("Failed to deserialize response");
+        }
+
+        return result;
+    }
+
+    public async Task<List<MMRCalculationResponse>> CalculateMMRBatchAsync(List<MMRCalculationRequest> requests)
+    {
+        var response = await httpClient.PostAsJsonAsync("api/v1/mmr-calculation/batch", requests);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<List<MMRCalculationResponse>>();
         if (result == null)
         {
             // TODO: Better exception

--- a/backend-dotnet/MMRProject.Api/Services/UserService.cs
+++ b/backend-dotnet/MMRProject.Api/Services/UserService.cs
@@ -13,7 +13,7 @@ public interface IUserService
     Task<User?> GetCurrentAuthenticatedUserAsync();
     Task<User> ClaimUserForCurrentAuthenticatedUserAsync(long userId);
     Task<(PlayerHistory history, long seasonId)?> LatestPlayerHistoryAsync(long userId);
-    Task<List<PlayerHistory>> LatestPlayerHistoriesAsync(List<long> userIds, long seasonId);
+    Task<List<(PlayerHistory history, long seasonId)>> LatestPlayerHistoriesAsync(List<long> userIds);
 }
 
 public class UserService(ILogger<UserService> logger, ApiDbContext dbContext, IUserContextResolver userContextResolver)
@@ -86,7 +86,7 @@ public class UserService(ILogger<UserService> logger, ApiDbContext dbContext, IU
 
         return user;
     }
-    
+
     public async Task<(PlayerHistory history, long seasonId)?> LatestPlayerHistoryAsync(long userId)
     {
         var playerHistory = await dbContext.PlayerHistories.Where(x => x.UserId == userId)
@@ -94,7 +94,7 @@ public class UserService(ILogger<UserService> logger, ApiDbContext dbContext, IU
             .OrderByDescending(x => x.MatchId)
             .AsNoTracking()
             .FirstOrDefaultAsync();
-        
+
         if (playerHistory?.Match?.SeasonId is null)
         {
             return null;
@@ -102,12 +102,18 @@ public class UserService(ILogger<UserService> logger, ApiDbContext dbContext, IU
 
         return (playerHistory, playerHistory.Match.SeasonId.Value);
     }
-    
-    public async Task<List<PlayerHistory>> LatestPlayerHistoriesAsync(List<long> userIds, long seasonId)
+
+    public async Task<List<(PlayerHistory history, long seasonId)>> LatestPlayerHistoriesAsync(List<long> userIds)
     {
-        return await dbContext.PlayerHistories.Where(x => userIds.Contains(x.User!.Id) && x.Match!.SeasonId == seasonId)
+        var playerHistories = await dbContext.PlayerHistories.Where(x => userIds.Contains(x.User!.Id))
+            .Include(x => x.Match)
             .GroupBy(x => x.UserId)
+            .AsNoTracking()
             .Select(x => x.OrderByDescending(y => y.MatchId).First())
             .ToListAsync();
+
+        return playerHistories.Where(x => x.Match?.SeasonId is not null)
+            .Select(x => (x, x.Match!.SeasonId!.Value))
+            .ToList();
     }
 }


### PR DESCRIPTION
Especially useful for recalculating the matches. Since there's an overhead for each request to the MMR api, we can optimize it by giving it multiple requests to handle at the same time