### PR TITLE
additional api-endpoints

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
         "@openapitools/openapi-generator-cli": "^2.13.4",
         "@sveltejs/adapter-auto": "^3.0.0",
         "@sveltejs/adapter-node": "^5.2.11",
-        "@sveltejs/kit": "^2.20.6",
+        "@sveltejs/kit": "^2.20.7",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
         "@types/eslint": "^8.56.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -2883,9 +2883,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "dev": true,
       "funding": [
         {

--- a/frontend/src/routes/(authed)/api/profile/+server.ts
+++ b/frontend/src/routes/(authed)/api/profile/+server.ts
@@ -1,0 +1,12 @@
+
+import { redirect } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ url, locals: { apiClient } }) => {
+  const { userId } = await apiClient.profileApi.profileGetProfile();
+
+  if (userId != null) {
+    redirect(303, `/api/profile/${userId}`);
+  }
+
+  return {};
+};

--- a/frontend/src/routes/(authed)/api/profile/[id]/+server.ts
+++ b/frontend/src/routes/(authed)/api/profile/[id]/+server.ts
@@ -1,0 +1,152 @@
+import type { RequestHandler } from './$types';
+import type { MemberLeaderboardEntry } from './types';
+
+export const GET: RequestHandler = async ({ 
+    params,
+    locals: { apiClient } },
+    url,
+) => {
+    const playerId = Number(params.id);
+    //const searchParams = url.searchParams;
+    const seasonId = undefined;/* searchParams.get('season')
+    ? Number(searchParams.get('season'))
+    : undefined;*/
+    const [userProfile, rawMatches, users, mmrHistory, seasons] =
+        await Promise.all([
+            apiClient.profileApi.profileGetProfile(),
+            apiClient.mmrApi.mMRV2GetMatches({
+                userId: playerId,
+                limit: 1000,
+                offset: 0,
+                seasonId,
+            }),
+            apiClient.usersApi.usersGetUsers(),
+            apiClient.statisticsApi.statisticsGetPlayerHistory({
+                userId: playerId,
+                seasonId,
+            }),
+            apiClient.seasonsApi.seasonsGetSeasons(),
+        ]);
+
+    const { userId: currentUserPlayerId } = userProfile;
+
+    const user = users.find((user) => user.userId === playerId);
+    if (!user) {
+        throw new Error('Player not found');
+    }
+
+    const mmr = mmrHistory[mmrHistory.length - 1]?.mmr;
+    const matches = rawMatches.map((match) =>
+        movePlayerToMember1(match, playerId)
+    );
+    const totalMatches = matches.length;
+    const wins = matches.filter((match) => {
+        const winnerTeam =
+            match.team1.score > match.team2.score ? match.team1 : match.team2;
+        return isOnTeam(winnerTeam, playerId);
+    }).length;
+    const lost = totalMatches - wins;
+    const winrate = totalMatches > 0 ? wins / totalMatches : 0;
+
+    const msSinceLastMatch = matches[0]
+        ? new Date(matches[0].date).getTime() - new Date().getTime()
+        : null;
+    const daysSinceLastMatch = msSinceLastMatch
+        ? millisecondsToDays(msSinceLastMatch)
+        : null;
+
+
+    const teammates = Object.entries(
+        matches
+            .map((match) => {
+                if (
+                    match.team1.member1 === playerId ||
+                        match.team1.member2 === playerId
+                ) {
+                    return match.team1;
+                }
+
+                return match.team2;
+            })
+            .reduce<Record<number, MemberLeaderboardEntry>>((acc, team) => {
+                const isWin = team.score === 10;
+                acc[team.member1] = {
+                    ...acc[team.member1],
+                    playerId: team.member1,
+                    wins: (acc[team.member1]?.wins ?? 0) + (isWin ? 1 : 0),
+                    losses: (acc[team.member1]?.losses ?? 0) + (isWin ? 0 : 1),
+                    total: (acc[team.member1]?.total ?? 0) + 1,
+                };
+                acc[team.member2] = {
+                    ...acc[team.member2],
+                    playerId: team.member2,
+                    wins: (acc[team.member2]?.wins ?? 0) + (isWin ? 1 : 0),
+                    losses: (acc[team.member2]?.losses ?? 0) + (isWin ? 0 : 1),
+                    total: (acc[team.member2]?.total ?? 0) + 1,
+                };
+                return acc;
+            }, {})
+    )
+    .filter(([, stats]) => stats.playerId !== playerId)
+    .sort((a, b) => b[1].total - a[1].total)
+    .map(([, stats]) => stats)
+    .slice(0, 5);
+
+    const opponents = Object.entries(
+        matches
+            .map((match) => {
+                if (
+                    match.team1.member1 === playerId ||
+                        match.team1.member2 === playerId
+                ) {
+                    return match.team2;
+                }
+
+                return match.team1;
+            })
+            .reduce<Record<number, MemberLeaderboardEntry>>((acc, team) => {
+                const isWin = team.score === 10;
+                acc[team.member1] = {
+                    ...acc[team.member1],
+                    playerId: team.member1,
+                    wins: (acc[team.member1]?.wins ?? 0) + (isWin ? 0 : 1),
+                    losses: (acc[team.member1]?.losses ?? 0) + (isWin ? 1 : 0),
+                    total: (acc[team.member1]?.total ?? 0) + 1,
+                };
+                acc[team.member2] = {
+                    ...acc[team.member2],
+                    playerId: team.member2,
+                    wins: (acc[team.member2]?.wins ?? 0) + (isWin ? 0 : 1),
+                    losses: (acc[team.member2]?.losses ?? 0) + (isWin ? 1 : 0),
+                    total: (acc[team.member2]?.total ?? 0) + 1,
+                };
+                return acc;
+            }, {})
+    )
+    .sort((a, b) => b[1].total - a[1].total)
+    .map(([, stats]) => stats)
+    .slice(0, 5);
+
+    return new Response(
+        JSON.stringify({
+            user, 
+            stats: {
+                mmr,
+                totalMatches,
+                wins,
+                lost,
+                winrate,
+                msSinceLastMatch,
+                daysSinceLastMatch,
+            },
+            mmrHistory,
+            //seasons,
+            matchHistory: {
+                matches,
+                teammates,
+                opponents,
+            },
+        })
+    );
+};
+


### PR DESCRIPTION
Hey chat,
I've added a few extra endpoints to `/api` in the frontend because I'd like to make a small tool (waybar-entry), and want easier access to my profiles data.
The endpoint(s) more-or-less correspond to a JSON-value version of the content in `/player/[id]`, meaning basically just some profile-specific data (mmr, history, etc.) regarding the current season.