### PR TITLE
Migrate from User to Player

### DIFF
--- a/api/MMRProject.Api/Data/ApiDbContext.cs
+++ b/api/MMRProject.Api/Data/ApiDbContext.cs
@@ -24,7 +24,7 @@ public partial class ApiDbContext : DbContext
 
     public virtual DbSet<Team> Teams { get; set; }
 
-    public virtual DbSet<User> Users { get; set; }
+    public virtual DbSet<Player> Players { get; set; }
 
     public virtual DbSet<QueuedPlayer> QueuedPlayers { get; set; }
 
@@ -109,15 +109,15 @@ public partial class ApiDbContext : DbContext
             entity.Property(e => e.Mu).HasColumnName("mu");
             entity.Property(e => e.Sigma).HasColumnName("sigma");
             entity.Property(e => e.UpdatedAt).HasColumnName("updated_at");
-            entity.Property(e => e.UserId).HasColumnName("user_id");
+            entity.Property(e => e.PlayerId).HasColumnName("player_id");
 
             entity.HasOne(d => d.Match).WithMany(p => p.PlayerHistories)
                 .HasForeignKey(d => d.MatchId)
                 .HasConstraintName("fk_player_histories_match");
 
-            entity.HasOne(d => d.User).WithMany(p => p.PlayerHistories)
-                .HasForeignKey(d => d.UserId)
-                .HasConstraintName("fk_player_histories_user");
+            entity.HasOne(d => d.Player).WithMany(p => p.PlayerHistories)
+                .HasForeignKey(d => d.PlayerId)
+                .HasConstraintName("fk_player_histories_player");
         });
 
         modelBuilder.Entity<Season>(entity =>
@@ -150,33 +150,33 @@ public partial class ApiDbContext : DbContext
             entity.Property(e => e.DeletedAt).HasColumnName("deleted_at");
             entity.Property(e => e.Score).HasColumnName("score");
             entity.Property(e => e.UpdatedAt).HasColumnName("updated_at");
-            entity.Property(e => e.UserOneId).HasColumnName("user_one_id");
-            entity.Property(e => e.UserTwoId).HasColumnName("user_two_id");
+            entity.Property(e => e.PlayerOneId).HasColumnName("player_one_id");
+            entity.Property(e => e.PlayerTwoId).HasColumnName("player_two_id");
             entity.Property(e => e.Winner).HasColumnName("winner");
 
-            entity.HasOne(d => d.UserOne).WithMany(p => p.TeamUserOnes)
-                .HasForeignKey(d => d.UserOneId)
-                .HasConstraintName("fk_teams_user_one");
+            entity.HasOne(d => d.PlayerOne).WithMany(p => p.TeamPlayerOnes)
+                .HasForeignKey(d => d.PlayerOneId)
+                .HasConstraintName("fk_teams_player_one");
 
-            entity.HasOne(d => d.UserTwo).WithMany(p => p.TeamUserTwos)
-                .HasForeignKey(d => d.UserTwoId)
-                .HasConstraintName("fk_teams_user_two");
+            entity.HasOne(d => d.PlayerTwo).WithMany(p => p.TeamPlayerTwos)
+                .HasForeignKey(d => d.PlayerTwoId)
+                .HasConstraintName("fk_teams_play_two");
         });
 
-        modelBuilder.Entity<User>(entity =>
+        modelBuilder.Entity<Player>(entity =>
         {
             entity.HasQueryFilter(e => e.DeletedAt == null);
             entity.HasKey(e => e.Id).HasName("users_pkey");
 
             entity.ToTable("users");
 
-            entity.HasIndex(e => e.DeletedAt, "idx_users_deleted_at");
+            entity.HasIndex(e => e.DeletedAt, "idx_players_deleted_at");
 
-            entity.HasIndex(e => e.IdentityUserId, "uni_users_identity_user_id").IsUnique();
+            entity.HasIndex(e => e.IdentityUserId, "uni_players_identity_user_id").IsUnique();
 
-            entity.HasIndex(e => e.Name, "uni_users_name").IsUnique();
+            entity.HasIndex(e => e.Name, "uni_players_name").IsUnique();
 
-            entity.HasIndex(e => e.Id, "users_id_key").IsUnique();
+            entity.HasIndex(e => e.Id, "players_id_key").IsUnique();
 
             entity.Property(e => e.Id).HasColumnName("id");
             entity.Property(e => e.CreatedAt).HasColumnName("created_at");
@@ -190,13 +190,13 @@ public partial class ApiDbContext : DbContext
             entity.Property(e => e.UpdatedAt).HasColumnName("updated_at");
         });
 
-        modelBuilder.Entity<QueuedPlayer>(entity => { entity.HasQueryFilter(e => e.User.DeletedAt == null); });
+        modelBuilder.Entity<QueuedPlayer>(entity => { entity.HasQueryFilter(e => e.Player.DeletedAt == null); });
 
         modelBuilder.Entity<ActiveMatch>(entity =>
         {
             entity.HasQueryFilter(e =>
-                e.TeamOneUserOne.DeletedAt == null && e.TeamOneUserTwo.DeletedAt == null &&
-                e.TeamTwoUserOne.DeletedAt == null && e.TeamTwoUserTwo.DeletedAt == null);
+                e.TeamOnePlayerOne.DeletedAt == null && e.TeamOnePlayerTwo.DeletedAt == null &&
+                e.TeamTwoPlayerOne.DeletedAt == null && e.TeamTwoPlayerTwo.DeletedAt == null);
         });
     }
 }

--- a/api/MMRProject.Api/Data/ApiDbContext.cs
+++ b/api/MMRProject.Api/Data/ApiDbContext.cs
@@ -166,9 +166,6 @@ public partial class ApiDbContext : DbContext
         modelBuilder.Entity<Player>(entity =>
         {
             entity.HasQueryFilter(e => e.DeletedAt == null);
-            entity.HasKey(e => e.Id).HasName("users_pkey");
-
-            entity.ToTable("users");
 
             entity.HasIndex(e => e.DeletedAt, "idx_players_deleted_at");
 

--- a/api/MMRProject.Api/Data/Entities/ActiveMatch.cs
+++ b/api/MMRProject.Api/Data/Entities/ActiveMatch.cs
@@ -3,15 +3,15 @@ namespace MMRProject.Api.Data.Entities;
 public class ActiveMatch: BaseEntity
 {
     public virtual PendingMatch? PendingMatch { get; set; }
-    public long TeamOneUserOneId { get; set; }
-    public virtual User TeamOneUserOne { get; set; } = null!;
+    public long TeamOnePlayerOneId { get; set; }
+    public virtual Player TeamOnePlayerOne { get; set; } = null!;
     
-    public long TeamOneUserTwoId { get; set; }
-    public virtual User TeamOneUserTwo { get; set; } = null!;
+    public long TeamOnePlayerTwoId { get; set; }
+    public virtual Player TeamOnePlayerTwo { get; set; } = null!;
     
-    public long TeamTwoUserOneId { get; set; }
-    public virtual User TeamTwoUserOne { get; set; } = null!;
+    public long TeamTwoPlayerOneId { get; set; }
+    public virtual Player TeamTwoPlayerOne { get; set; } = null!;
     
-    public long TeamTwoUserTwoId { get; set; }
-    public virtual User TeamTwoUserTwo { get; set; } = null!;
+    public long TeamTwoPlayerTwoId { get; set; }
+    public virtual Player TeamTwoPlayerTwo { get; set; } = null!;
 }

--- a/api/MMRProject.Api/Data/Entities/Player.cs
+++ b/api/MMRProject.Api/Data/Entities/Player.cs
@@ -1,6 +1,6 @@
 ﻿namespace MMRProject.Api.Data.Entities;
 
-public class User
+public class Player
 {
     public long Id { get; set; }
 
@@ -24,7 +24,7 @@ public class User
 
     public virtual ICollection<PlayerHistory> PlayerHistories { get; set; } = new List<PlayerHistory>();
 
-    public virtual ICollection<Team> TeamUserOnes { get; set; } = new List<Team>();
+    public virtual ICollection<Team> TeamPlayerOnes { get; set; } = new List<Team>();
 
-    public virtual ICollection<Team> TeamUserTwos { get; set; } = new List<Team>();
+    public virtual ICollection<Team> TeamPlayerTwos { get; set; } = new List<Team>();
 }

--- a/api/MMRProject.Api/Data/Entities/PlayerHistory.cs
+++ b/api/MMRProject.Api/Data/Entities/PlayerHistory.cs
@@ -10,7 +10,7 @@ public class PlayerHistory
 
     public DateTime? DeletedAt { get; set; }
 
-    public long? UserId { get; set; }
+    public long? PlayerId { get; set; }
 
     public long? Mmr { get; set; }
 
@@ -22,5 +22,5 @@ public class PlayerHistory
 
     public virtual Match? Match { get; set; }
 
-    public virtual User? User { get; set; }
+    public virtual Player? Player { get; set; }
 }

--- a/api/MMRProject.Api/Data/Entities/QueuedPlayer.cs
+++ b/api/MMRProject.Api/Data/Entities/QueuedPlayer.cs
@@ -2,9 +2,9 @@ namespace MMRProject.Api.Data.Entities;
 
 public class QueuedPlayer : BaseEntity
 {
-    public long UserId { get; set; }
+    public long PlayerId { get; set; }
 
-    public virtual User User { get; set; } = null!;
+    public virtual Player Player { get; set; } = null!;
 
     public virtual PendingMatch? PendingMatch { get; set; }
 

--- a/api/MMRProject.Api/Data/Entities/Team.cs
+++ b/api/MMRProject.Api/Data/Entities/Team.cs
@@ -10,9 +10,9 @@ public class Team
 
     public DateTime? DeletedAt { get; set; }
 
-    public long? UserOneId { get; set; }
+    public long? PlayerOneId { get; set; }
 
-    public long? UserTwoId { get; set; }
+    public long? PlayerTwoId { get; set; }
 
     public long? Score { get; set; }
 
@@ -22,7 +22,7 @@ public class Team
 
     public virtual ICollection<Match> MatchTeamTwos { get; set; } = new List<Match>();
 
-    public virtual User? UserOne { get; set; }
+    public virtual Player? PlayerOne { get; set; }
 
-    public virtual User? UserTwo { get; set; }
+    public virtual Player? PlayerTwo { get; set; }
 }

--- a/api/MMRProject.Api/Data/Migrations/20250930061506_MigrateFromUsersToPlayers1.Designer.cs
+++ b/api/MMRProject.Api/Data/Migrations/20250930061506_MigrateFromUsersToPlayers1.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MMRProject.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MMRProject.Api.Data.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250930061506_MigrateFromUsersToPlayers1")]
+    partial class MigrateFromUsersToPlayers1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -228,7 +231,8 @@ namespace MMRProject.Api.Data.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
 
-                    b.HasKey("Id");
+                    b.HasKey("Id")
+                        .HasName("users_pkey");
 
                     b.HasIndex(new[] { "DeletedAt" }, "idx_players_deleted_at");
 
@@ -241,7 +245,7 @@ namespace MMRProject.Api.Data.Migrations
                     b.HasIndex(new[] { "Name" }, "uni_players_name")
                         .IsUnique();
 
-                    b.ToTable("Players");
+                    b.ToTable("users", (string)null);
                 });
 
             modelBuilder.Entity("MMRProject.Api.Data.Entities.PlayerHistory", b =>

--- a/api/MMRProject.Api/Data/Migrations/20250930061506_MigrateFromUsersToPlayers1.cs
+++ b/api/MMRProject.Api/Data/Migrations/20250930061506_MigrateFromUsersToPlayers1.cs
@@ -1,0 +1,401 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MMRProject.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MigrateFromUsersToPlayers1 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamOneUserOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamOneUserTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoUserOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoUserTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_player_histories_user",
+                table: "player_histories");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_QueuedPlayers_users_UserId",
+                table: "QueuedPlayers");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_teams_user_one",
+                table: "teams");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_teams_user_two",
+                table: "teams");
+
+            migrationBuilder.RenameIndex(
+                name: "users_id_key",
+                table: "users",
+                newName: "players_id_key");
+
+            migrationBuilder.RenameIndex(
+                name: "uni_users_name",
+                table: "users",
+                newName: "uni_players_name");
+
+            migrationBuilder.RenameIndex(
+                name: "uni_users_identity_user_id",
+                table: "users",
+                newName: "uni_players_identity_user_id");
+
+            migrationBuilder.RenameIndex(
+                name: "idx_users_deleted_at",
+                table: "users",
+                newName: "idx_players_deleted_at");
+
+            migrationBuilder.RenameColumn(
+                name: "user_two_id",
+                table: "teams",
+                newName: "player_two_id");
+
+            migrationBuilder.RenameColumn(
+                name: "user_one_id",
+                table: "teams",
+                newName: "player_one_id");
+
+            migrationBuilder.RenameColumn(
+                name: "UserId",
+                table: "QueuedPlayers",
+                newName: "PlayerId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_QueuedPlayers_UserId",
+                table: "QueuedPlayers",
+                newName: "IX_QueuedPlayers_PlayerId");
+
+            migrationBuilder.RenameColumn(
+                name: "user_id",
+                table: "player_histories",
+                newName: "player_id");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamTwoUserTwoId",
+                table: "ActiveMatches",
+                newName: "TeamTwoPlayerTwoId");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamTwoUserOneId",
+                table: "ActiveMatches",
+                newName: "TeamTwoPlayerOneId");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamOneUserTwoId",
+                table: "ActiveMatches",
+                newName: "TeamOnePlayerTwoId");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamOneUserOneId",
+                table: "ActiveMatches",
+                newName: "TeamOnePlayerOneId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamTwoUserTwoId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamTwoPlayerTwoId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamTwoUserOneId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamTwoPlayerOneId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamOneUserTwoId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamOnePlayerTwoId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamOneUserOneId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamOnePlayerOneId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_teams_player_one_id",
+                table: "teams",
+                column: "player_one_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_teams_player_two_id",
+                table: "teams",
+                column: "player_two_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_player_histories_player_id",
+                table: "player_histories",
+                column: "player_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerOneId",
+                table: "ActiveMatches",
+                column: "TeamOnePlayerOneId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerTwoId",
+                table: "ActiveMatches",
+                column: "TeamOnePlayerTwoId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerOneId",
+                table: "ActiveMatches",
+                column: "TeamTwoPlayerOneId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerTwoId",
+                table: "ActiveMatches",
+                column: "TeamTwoPlayerTwoId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_player_histories_player",
+                table: "player_histories",
+                column: "player_id",
+                principalTable: "users",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QueuedPlayers_users_PlayerId",
+                table: "QueuedPlayers",
+                column: "PlayerId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_teams_play_two",
+                table: "teams",
+                column: "player_two_id",
+                principalTable: "users",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_teams_player_one",
+                table: "teams",
+                column: "player_one_id",
+                principalTable: "users",
+                principalColumn: "id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_player_histories_player",
+                table: "player_histories");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_QueuedPlayers_users_PlayerId",
+                table: "QueuedPlayers");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_teams_play_two",
+                table: "teams");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_teams_player_one",
+                table: "teams");
+
+            migrationBuilder.DropIndex(
+                name: "IX_teams_player_one_id",
+                table: "teams");
+
+            migrationBuilder.DropIndex(
+                name: "IX_teams_player_two_id",
+                table: "teams");
+
+            migrationBuilder.DropIndex(
+                name: "IX_player_histories_player_id",
+                table: "player_histories");
+
+            migrationBuilder.RenameIndex(
+                name: "uni_players_name",
+                table: "users",
+                newName: "uni_users_name");
+
+            migrationBuilder.RenameIndex(
+                name: "uni_players_identity_user_id",
+                table: "users",
+                newName: "uni_users_identity_user_id");
+
+            migrationBuilder.RenameIndex(
+                name: "players_id_key",
+                table: "users",
+                newName: "users_id_key");
+
+            migrationBuilder.RenameIndex(
+                name: "idx_players_deleted_at",
+                table: "users",
+                newName: "idx_users_deleted_at");
+
+            migrationBuilder.RenameColumn(
+                name: "player_two_id",
+                table: "teams",
+                newName: "user_two_id");
+
+            migrationBuilder.RenameColumn(
+                name: "player_one_id",
+                table: "teams",
+                newName: "user_one_id");
+
+            migrationBuilder.RenameColumn(
+                name: "PlayerId",
+                table: "QueuedPlayers",
+                newName: "UserId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_QueuedPlayers_PlayerId",
+                table: "QueuedPlayers",
+                newName: "IX_QueuedPlayers_UserId");
+
+            migrationBuilder.RenameColumn(
+                name: "player_id",
+                table: "player_histories",
+                newName: "user_id");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamTwoPlayerTwoId",
+                table: "ActiveMatches",
+                newName: "TeamTwoUserTwoId");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamTwoPlayerOneId",
+                table: "ActiveMatches",
+                newName: "TeamTwoUserOneId");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamOnePlayerTwoId",
+                table: "ActiveMatches",
+                newName: "TeamOneUserTwoId");
+
+            migrationBuilder.RenameColumn(
+                name: "TeamOnePlayerOneId",
+                table: "ActiveMatches",
+                newName: "TeamOneUserOneId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamTwoPlayerTwoId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamTwoUserTwoId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamTwoPlayerOneId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamTwoUserOneId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamOnePlayerTwoId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamOneUserTwoId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActiveMatches_TeamOnePlayerOneId",
+                table: "ActiveMatches",
+                newName: "IX_ActiveMatches_TeamOneUserOneId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamOneUserOneId",
+                table: "ActiveMatches",
+                column: "TeamOneUserOneId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamOneUserTwoId",
+                table: "ActiveMatches",
+                column: "TeamOneUserTwoId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoUserOneId",
+                table: "ActiveMatches",
+                column: "TeamTwoUserOneId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoUserTwoId",
+                table: "ActiveMatches",
+                column: "TeamTwoUserTwoId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_player_histories_user",
+                table: "player_histories",
+                column: "user_id",
+                principalTable: "users",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QueuedPlayers_users_UserId",
+                table: "QueuedPlayers",
+                column: "UserId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_teams_user_one",
+                table: "teams",
+                column: "user_one_id",
+                principalTable: "users",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_teams_user_two",
+                table: "teams",
+                column: "user_two_id",
+                principalTable: "users",
+                principalColumn: "id");
+        }
+    }
+}

--- a/api/MMRProject.Api/Data/Migrations/20250930061542_MigrateFromUsersToPlayers2.Designer.cs
+++ b/api/MMRProject.Api/Data/Migrations/20250930061542_MigrateFromUsersToPlayers2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MMRProject.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MMRProject.Api.Data.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250930061542_MigrateFromUsersToPlayers2")]
+    partial class MigrateFromUsersToPlayers2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/MMRProject.Api/Data/Migrations/20250930061542_MigrateFromUsersToPlayers2.cs
+++ b/api/MMRProject.Api/Data/Migrations/20250930061542_MigrateFromUsersToPlayers2.cs
@@ -1,0 +1,164 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MMRProject.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MigrateFromUsersToPlayers2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_QueuedPlayers_users_PlayerId",
+                table: "QueuedPlayers");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "users_pkey",
+                table: "users");
+
+            migrationBuilder.RenameTable(
+                name: "users",
+                newName: "Players");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Players",
+                table: "Players",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_Players_TeamOnePlayerOneId",
+                table: "ActiveMatches",
+                column: "TeamOnePlayerOneId",
+                principalTable: "Players",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_Players_TeamOnePlayerTwoId",
+                table: "ActiveMatches",
+                column: "TeamOnePlayerTwoId",
+                principalTable: "Players",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_Players_TeamTwoPlayerOneId",
+                table: "ActiveMatches",
+                column: "TeamTwoPlayerOneId",
+                principalTable: "Players",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_Players_TeamTwoPlayerTwoId",
+                table: "ActiveMatches",
+                column: "TeamTwoPlayerTwoId",
+                principalTable: "Players",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QueuedPlayers_Players_PlayerId",
+                table: "QueuedPlayers",
+                column: "PlayerId",
+                principalTable: "Players",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_Players_TeamOnePlayerOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_Players_TeamOnePlayerTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_Players_TeamTwoPlayerOneId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActiveMatches_Players_TeamTwoPlayerTwoId",
+                table: "ActiveMatches");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_QueuedPlayers_Players_PlayerId",
+                table: "QueuedPlayers");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Players",
+                table: "Players");
+
+            migrationBuilder.RenameTable(
+                name: "Players",
+                newName: "users");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "users_pkey",
+                table: "users",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerOneId",
+                table: "ActiveMatches",
+                column: "TeamOnePlayerOneId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamOnePlayerTwoId",
+                table: "ActiveMatches",
+                column: "TeamOnePlayerTwoId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerOneId",
+                table: "ActiveMatches",
+                column: "TeamTwoPlayerOneId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActiveMatches_users_TeamTwoPlayerTwoId",
+                table: "ActiveMatches",
+                column: "TeamTwoPlayerTwoId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QueuedPlayers_users_PlayerId",
+                table: "QueuedPlayers",
+                column: "PlayerId",
+                principalTable: "users",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/api/MMRProject.Api/Data/Migrations/ApiDbContextModelSnapshot.cs
+++ b/api/MMRProject.Api/Data/Migrations/ApiDbContextModelSnapshot.cs
@@ -229,8 +229,6 @@ namespace MMRProject.Api.Data.Migrations
 
                     b.HasIndex("MatchId");
 
-                    b.HasIndex("UserId");
-
                     b.HasIndex(new[] { "DeletedAt" }, "idx_player_histories_deleted_at");
 
                     b.ToTable("player_histories", (string)null);
@@ -335,10 +333,6 @@ namespace MMRProject.Api.Data.Migrations
 
                     b.HasKey("Id")
                         .HasName("teams_pkey");
-
-                    b.HasIndex("UserOneId");
-
-                    b.HasIndex("UserTwoId");
 
                     b.HasIndex(new[] { "DeletedAt" }, "idx_teams_deleted_at");
 

--- a/api/MMRProject.Api/Mappers/ActiveMatchMapper.cs
+++ b/api/MMRProject.Api/Mappers/ActiveMatchMapper.cs
@@ -15,16 +15,16 @@ public static class ActiveMatchMapper
             {
                 PlayerIds = new List<long>
                 {
-                    activeMatch.TeamOneUserOneId,
-                    activeMatch.TeamOneUserTwoId
+                    activeMatch.TeamOnePlayerOneId,
+                    activeMatch.TeamOnePlayerTwoId
                 }
             },
             Team2 = new ActiveMatchTeamDto
             {
                 PlayerIds = new List<long>
                 {
-                    activeMatch.TeamTwoUserOneId,
-                    activeMatch.TeamTwoUserTwoId
+                    activeMatch.TeamTwoPlayerOneId,
+                    activeMatch.TeamTwoPlayerTwoId
                 }
             }
         };

--- a/api/MMRProject.Api/Mappers/MatchMapper.cs
+++ b/api/MMRProject.Api/Mappers/MatchMapper.cs
@@ -31,7 +31,7 @@ public static class MatchMapper
 
     private static MatchTeamV2? MapTeamToMatchTeam(Team? team)
     {
-        if (team?.Score is null || team.UserOneId is null || team.UserTwoId is null)
+        if (team?.Score is null || team.PlayerOneId is null || team.PlayerTwoId is null)
         {
             return null;
         }
@@ -39,8 +39,8 @@ public static class MatchMapper
         return new MatchTeamV2
         {
             Score = (int)team.Score.Value,
-            Member1 = team.UserOneId.Value,
-            Member2 = team.UserTwoId.Value
+            Member1 = team.PlayerOneId.Value,
+            Member2 = team.PlayerTwoId.Value
         };
     }
     

--- a/api/MMRProject.Api/Mappers/PlayerHistoryMapper.cs
+++ b/api/MMRProject.Api/Mappers/PlayerHistoryMapper.cs
@@ -9,8 +9,8 @@ public static class PlayerHistoryMapper
     {
         return new PlayerHistoryDetails
         {
-            UserId = playerHistory.UserId ?? 0, // TODO: Fix this
-            Name = playerHistory.User?.Name ?? string.Empty, // TODO: Fix this
+            UserId = playerHistory.PlayerId ?? 0, // TODO: Fix this
+            Name = playerHistory.Player?.Name ?? string.Empty, // TODO: Fix this
             Date = playerHistory.Match?.CreatedAt ?? DateTimeOffset.UtcNow, // TODO: Fix this
             MMR = playerHistory.Mmr ?? 0, // TODO: Fix this
         };

--- a/api/MMRProject.Api/Mappers/UserMapper.cs
+++ b/api/MMRProject.Api/Mappers/UserMapper.cs
@@ -5,13 +5,13 @@ namespace MMRProject.Api.Mappers;
 
 public static class UserMapper
 {
-    public static UserDetails MapUserToUserDetails(User user)
+    public static UserDetails MapUserToUserDetails(Player player)
     {
         return new UserDetails
         {
-            UserId = user.Id,
-            Name = user.Name ?? string.Empty, // TODO: Fix this
-            DisplayName = user.DisplayName
+            UserId = player.Id,
+            Name = player.Name ?? string.Empty, // TODO: Fix this
+            DisplayName = player.DisplayName
         };
     }
 }

--- a/api/MMRProject.Api/Services/StatisticsService.cs
+++ b/api/MMRProject.Api/Services/StatisticsService.cs
@@ -28,7 +28,7 @@ public class StatisticsService(ApiDbContext dbContext, IUserService userService)
                                   ELSE 0
                               END AS IsWin,
                               ROW_NUMBER() OVER (PARTITION BY u.Id ORDER BY m.Id DESC) AS RowNum
-                          FROM players u
+                          FROM "Players" u
                           LEFT JOIN teams t ON u.Id = t.player_one_id OR u.Id = t.player_two_id
                           LEFT JOIN matches m ON t.Id = m.team_one_id OR t.Id = m.team_two_id
                           WHERE m.season_id = {0}
@@ -73,7 +73,7 @@ public class StatisticsService(ApiDbContext dbContext, IUserService userService)
                               ORDER BY ph.match_id DESC
                               LIMIT 1
                           ) AS MMR
-                      FROM players u
+                      FROM "Players" u
                       LEFT JOIN teams t ON u.Id = t.player_one_id OR u.Id = t.player_two_id
                       LEFT JOIN matches m ON t.Id = m.team_one_id OR t.Id = m.team_two_id
                       LEFT JOIN CurrentStreak cs ON u.Id = cs.UserId

--- a/api/MMRProject.Api/Services/StatisticsService.cs
+++ b/api/MMRProject.Api/Services/StatisticsService.cs
@@ -28,8 +28,8 @@ public class StatisticsService(ApiDbContext dbContext, IUserService userService)
                                   ELSE 0
                               END AS IsWin,
                               ROW_NUMBER() OVER (PARTITION BY u.Id ORDER BY m.Id DESC) AS RowNum
-                          FROM users u
-                          LEFT JOIN teams t ON u.Id = t.user_one_id OR u.Id = t.user_two_id
+                          FROM players u
+                          LEFT JOIN teams t ON u.Id = t.player_one_id OR u.Id = t.player_two_id
                           LEFT JOIN matches m ON t.Id = m.team_one_id OR t.Id = m.team_two_id
                           WHERE m.season_id = {0}
                       ),
@@ -69,12 +69,12 @@ public class StatisticsService(ApiDbContext dbContext, IUserService userService)
                               SELECT ph.Mmr
                               FROM player_histories ph
                               LEFT JOIN matches m ON ph.match_id = m.id
-                              WHERE ph.user_id = u.id AND m.season_id = {0}
+                              WHERE ph.player_id = u.id AND m.season_id = {0}
                               ORDER BY ph.match_id DESC
                               LIMIT 1
                           ) AS MMR
-                      FROM users u
-                      LEFT JOIN teams t ON u.Id = t.user_one_id OR u.Id = t.user_two_id
+                      FROM players u
+                      LEFT JOIN teams t ON u.Id = t.player_one_id OR u.Id = t.player_two_id
                       LEFT JOIN matches m ON t.Id = m.team_one_id OR t.Id = m.team_two_id
                       LEFT JOIN CurrentStreak cs ON u.Id = cs.UserId
                       GROUP BY u.Id, u.Name, cs.StreakLength, cs.IsWin
@@ -137,13 +137,13 @@ public class StatisticsService(ApiDbContext dbContext, IUserService userService)
     public async Task<IEnumerable<PlayerHistoryDetails>> GetPlayerHistoryAsync(long seasonId, long? userId)
     {
         var query = dbContext.PlayerHistories
-            .Include(x => x.User)
+            .Include(x => x.Player)
             .Include(x => x.Match)
             .Where(x => x.Match!.SeasonId == seasonId);
 
         if (userId.HasValue)
         {
-            query = query.Where(x => x.UserId == userId);
+            query = query.Where(x => x.PlayerId == userId);
         }
 
         var playerHistories = await query
@@ -152,13 +152,13 @@ public class StatisticsService(ApiDbContext dbContext, IUserService userService)
 
         // Count occurrences of user id in player histories
         var userIdOccurrences = playerHistories
-            .Select(x => x.UserId)
+            .Select(x => x.PlayerId)
             .WhereNotNull()
             .GroupBy(x => x)
             .ToDictionary(x => x.Key, x => x.Count());
 
         var filteredPlayerHistories = playerHistories
-            .Where(x => x.UserId.HasValue && userIdOccurrences[x.UserId.Value] >= 10);
+            .Where(x => x.PlayerId.HasValue && userIdOccurrences[x.PlayerId.Value] >= 10);
 
         return filteredPlayerHistories.Select(PlayerHistoryMapper.MapPlayerHistoryToPlayerHistoryDetails);
     }


### PR DESCRIPTION
This PR restructures our model to distinguish between **users** and **players**, in order to simplify support for features like multi-tenancy.

## Background
At present, our `User` entity directly holds **player history** and **MMR calculations**, all tied to matches.  
This creates problems if we want to support multi-tenancy:
- Player histories would need to be split or tracked separately per organisation.  
- Names would also need to vary per organisation, since a user may be referred to by one name in one organisation and another name in another.  

As a result, layering multi-tenancy onto the current model would introduce significant complexity.

## The New Model
- **User**: The single account you log in with.  
- **Player**: A representation of that user within a specific organisation, server, or leaderboard.  
  - A user can have multiple players (one per organisation/leaderboard).  
  - Each player keeps its own history and MMR.  
  - Players allow flexible naming (e.g., gamer tag in a private setup, initials in a work setup).

This is conceptually similar to Discord, where you have one account but can set different names per server—though the implementation here is different.

## Benefits
- Cleaner support for multi-tenancy. 
- Flexible identity (different names/initials per organisation).  
- Reduced coupling between user identity and organisation-specific participation/history.