### PR TITLE
Prepare Database for Clerk Migration: Add Email and Auto-Linking

### DIFF
--- a/api/MMRProject.Api/Data/ApiDbContext.cs
+++ b/api/MMRProject.Api/Data/ApiDbContext.cs
@@ -177,11 +177,15 @@ public partial class ApiDbContext : DbContext
 
             entity.HasIndex(e => e.Id, "players_id_key").IsUnique();
 
+            entity.HasIndex(e => e.Email, "idx_players_email");
+
             entity.Property(e => e.Id).HasColumnName("id");
             entity.Property(e => e.CreatedAt).HasColumnName("created_at");
             entity.Property(e => e.DeletedAt).HasColumnName("deleted_at");
             entity.Property(e => e.DisplayName).HasColumnName("display_name");
             entity.Property(e => e.IdentityUserId).HasColumnName("identity_user_id");
+            entity.Property(e => e.Email).HasColumnName("email").HasMaxLength(128);
+            entity.Property(e => e.MigratedAt).HasColumnName("migrated_at");
             entity.Property(e => e.Mmr).HasColumnName("mmr");
             entity.Property(e => e.Mu).HasColumnName("mu");
             entity.Property(e => e.Name).HasColumnName("name");

--- a/api/MMRProject.Api/Data/Entities/Player.cs
+++ b/api/MMRProject.Api/Data/Entities/Player.cs
@@ -22,6 +22,10 @@ public class Player
 
     public string? IdentityUserId { get; set; }
 
+    public string? Email { get; set; }
+
+    public DateTime? MigratedAt { get; set; }
+
     public virtual ICollection<PlayerHistory> PlayerHistories { get; set; } = new List<PlayerHistory>();
 
     public virtual ICollection<Team> TeamPlayerOnes { get; set; } = new List<Team>();

--- a/api/MMRProject.Api/Data/Migrations/20251011233632_AddEmailAndMigratedAtToPlayer.Designer.cs
+++ b/api/MMRProject.Api/Data/Migrations/20251011233632_AddEmailAndMigratedAtToPlayer.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MMRProject.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MMRProject.Api.Data.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251011233632_AddEmailAndMigratedAtToPlayer")]
+    partial class AddEmailAndMigratedAtToPlayer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/MMRProject.Api/Data/Migrations/20251011233632_AddEmailAndMigratedAtToPlayer.cs
+++ b/api/MMRProject.Api/Data/Migrations/20251011233632_AddEmailAndMigratedAtToPlayer.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MMRProject.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailAndMigratedAtToPlayer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "email",
+                table: "Players",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "migrated_at",
+                table: "Players",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_players_email",
+                table: "Players",
+                column: "email");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_players_email",
+                table: "Players");
+
+            migrationBuilder.DropColumn(
+                name: "email",
+                table: "Players");
+
+            migrationBuilder.DropColumn(
+                name: "migrated_at",
+                table: "Players");
+        }
+    }
+}

--- a/api/MMRProject.Api/Services/MatchMakingService.cs
+++ b/api/MMRProject.Api/Services/MatchMakingService.cs
@@ -24,6 +24,7 @@ public interface IMatchMakingService
 public class MatchMakingService(
     ILogger<MatchMakingService> logger,
     IUserContextResolver userContextResolver,
+    IUserService userService,
     ApiDbContext dbContext,
     IMatchesService matchesService,
     ISeasonService seasonService
@@ -31,10 +32,7 @@ public class MatchMakingService(
 {
     public async Task AddPlayerToQueueAsync()
     {
-        var identityUserId = userContextResolver.GetIdentityUserId();
-
-        var currentUser = await dbContext.Players
-            .FirstOrDefaultAsync(x => x.IdentityUserId == identityUserId);
+        var currentUser = await userService.GetCurrentAuthenticatedUserAsync();
 
         if (currentUser is null)
         {
@@ -47,7 +45,7 @@ public class MatchMakingService(
 
         if (currentQueuedPlayer is not null)
         {
-            logger.LogInformation("User {IdentityUserId} already in queue", identityUserId);
+            logger.LogInformation("Player {PlayerId} already in queue", currentUser.Id);
             return;
         }
 

--- a/api/MMRProject.Api/Services/UserService.cs
+++ b/api/MMRProject.Api/Services/UserService.cs
@@ -81,8 +81,8 @@ public class UserService(ILogger<UserService> logger, ApiDbContext dbContext, IU
         }
 
         logger.LogInformation(
-            "Auto-linking Player {PlayerId} (email: {Email}) to identity user {IdentityUserId}",
-            player.Id, email, identityUserId);
+            "Auto-linking Player {PlayerId} to identity user {IdentityUserId}",
+            player.Id, identityUserId);
 
         player.IdentityUserId = identityUserId;
         player.MigratedAt = DateTime.UtcNow;

--- a/api/MMRProject.Api/UserContext/UserContextResolver.cs
+++ b/api/MMRProject.Api/UserContext/UserContextResolver.cs
@@ -7,6 +7,7 @@ public interface IUserContextResolver
 {
     ClaimsPrincipal GetUserIdentity();
     string GetIdentityUserId();
+    string? GetEmail();
     bool IsPatAuthentication();
 }
 
@@ -14,6 +15,7 @@ public class UserContextResolver : IUserContextResolver
 {
     private readonly ClaimsPrincipal _user;
     private readonly Lazy<string> _userId;
+    private readonly Lazy<string?> _email;
 
     public UserContextResolver(IHttpContextAccessor httpContextAccessor)
     {
@@ -23,11 +25,17 @@ public class UserContextResolver : IUserContextResolver
         _userId = new Lazy<string>(
             () => _user.GetUserId() ?? throw new Exception("Missing user id")
         );
+        _email = new Lazy<string?>(
+            () => _user.FindFirstValue(ClaimTypes.Email)
+                ?? _user.FindFirstValue("email")
+        );
     }
 
     public ClaimsPrincipal GetUserIdentity() => _user;
 
     public string GetIdentityUserId() => _userId.Value;
+
+    public string? GetEmail() => _email.Value;
 
     public bool IsPatAuthentication()
     {

--- a/api/MMRProject.Api/scripts/generate-backfill-sql.sh
+++ b/api/MMRProject.Api/scripts/generate-backfill-sql.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# generate-backfill-sql.sh
+# Generates SQL to backfill Player.Email from CSV export
+
+CSV_FILE="${1:-user_emails.csv}"
+OUTPUT_FILE="backfill-player-emails.sql"
+
+if [ ! -f "$CSV_FILE" ]; then
+    echo "Error: CSV file not found: $CSV_FILE"
+    exit 1
+fi
+
+echo "-- Generated: $(date)" > "$OUTPUT_FILE"
+echo "-- Source: $CSV_FILE" >> "$OUTPUT_FILE"
+echo "" >> "$OUTPUT_FILE"
+
+tail -n +2 "$CSV_FILE" | while IFS=, read -r identity_user_id email; do
+    identity_user_id=$(echo "$identity_user_id" | tr -d '"')
+    email=$(echo "$email" | tr -d '"')
+
+    email=$(echo "$email" | sed "s/'/''/g")
+
+    echo "UPDATE players SET email = '$email', updated_at = NOW() WHERE identity_user_id = '$identity_user_id' AND email IS NULL;" >> "$OUTPUT_FILE"
+done
+
+echo "" >> "$OUTPUT_FILE"
+echo "-- Validation query:" >> "$OUTPUT_FILE"
+echo "-- SELECT COUNT(*) as total, COUNT(email) as with_email, COUNT(*) - COUNT(email) as missing_email" >> "$OUTPUT_FILE"
+echo "-- FROM players WHERE deleted_at IS NULL AND identity_user_id IS NOT NULL;" >> "$OUTPUT_FILE"
+
+echo "Generated SQL file: $OUTPUT_FILE"


### PR DESCRIPTION
## Summary

Prepares the database for migration from Supabase to Clerk authentication by adding email-based auto-linking functionality. This PR implements issue #176 and must be deployed **before** #174 (Clerk Authentication Implementation).

### Changes Made

- ✅ Added `Email` property to Player entity (nullable string, max 128 chars)
- ✅ Added `MigratedAt` timestamp to track migration status
- ✅ Configured `email` column with index in ApiDbContext
- ✅ Created EF Core migration: `AddEmailAndMigratedAtToPlayer`
- ✅ Implemented auto-linking logic in `UserService.GetCurrentAuthenticatedUserAsync()`
- ✅ Added `GetEmail()` method to `IUserContextResolver` interface with claim fallback
- ✅ Created bash script `scripts/generate-backfill-sql.sh` to generate SQL backfill from CSV

### Auto-Linking Flow

When a user authenticates (on every request to `GetCurrentAuthenticatedUserAsync`):

1. **Check for existing link**: Look up player by `identity_user_id` (Clerk user ID)
2. **If not found**: Extract email from JWT claims via `UserContextResolver.GetEmail()`
3. **Search by email**: Query for player with matching email where `migrated_at IS NULL`
4. **Auto-link if found**: 
   - Set `player.identity_user_id` to the new Clerk user ID
   - Set `player.migrated_at` to current timestamp
   - Update `player.updated_at`
   - Save changes and log the auto-link event
5. **Return**: The linked player (or null if no match)

### Why MigratedAt?

Users coming from Supabase already have an `identity_user_id` (their Supabase UUID). When they log in with Clerk for the first time, they'll have a different Clerk user ID. The `migrated_at` field ensures:
- Players can only be auto-linked **once** (prevents re-linking)
- We can track which players have been successfully migrated
- Audit trail for the migration process

### Deployment Steps

After merging and deploying this PR:

1. **Migration runs automatically** on API startup
2. **Generate backfill SQL**:
   ```bash
   cd api/MMRProject.Api/scripts
   ./generate-backfill-sql.sh /path/to/user_emails.csv
   ```
3. **Review generated SQL**: `cat backfill-player-emails.sql`
4. **Execute against database**:
   ```bash
   psql -h <host> -U <user> -d <database> -f backfill-player-emails.sql
   ```
5. **Validate backfill**:
   ```sql
   SELECT COUNT(*) as total, COUNT(email) as with_email, COUNT(*) - COUNT(email) as missing_email
   FROM players WHERE deleted_at IS NULL AND identity_user_id IS NOT NULL;
   ```

### Testing Checklist

- [x] Player entity has `Email` and `MigratedAt` properties
- [x] ApiDbContext configures columns with proper types
- [x] EF Core migration created successfully
- [x] Auto-linking logic checks `migrated_at IS NULL`
- [x] Auto-linking sets `migrated_at` timestamp
- [x] Bash script generates valid SQL with proper escaping
- [x] API builds successfully
- [x] `UserContextResolver.GetEmail()` has claim fallback logic

### Notes

- **This PR does NOT implement Clerk authentication** - it only prepares the database
- **This PR does NOT change authentication behavior** - Supabase auth continues to work
- Email backfill should be run **immediately after deployment** and **before** deploying #174
- All game history, matches, stats, and MMR data remain intact through migration

### References

- **Fixes:** #176
- **Blocks:** #174 (Clerk Authentication Implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)