### PR TITLE
feat: add touch-based team randomizer

### DIFF
--- a/frontend/src/routes/(authed)/random/+page.svelte
+++ b/frontend/src/routes/(authed)/random/+page.svelte
@@ -78,7 +78,9 @@
       });
     }
 
-    resetCountdown();
+    if (touches.length >= 4) {
+      resetCountdown();
+    }
   }
 
   function handleTouchMove(event: TouchEvent) {
@@ -110,6 +112,14 @@
       if (index !== -1) {
         touches.splice(index, 1);
       }
+    }
+
+    if (touches.length < 4) {
+      if (countdownTimer !== null) {
+        clearInterval(countdownTimer);
+        countdownTimer = null;
+      }
+      countdown = null;
     }
   }
 

--- a/frontend/src/routes/(authed)/random/+page.svelte
+++ b/frontend/src/routes/(authed)/random/+page.svelte
@@ -123,7 +123,7 @@
     }
 
     showingResult = false;
-    countdown = 5;
+    countdown = 3;
     countdownTimer = setInterval(() => {
       if (countdown !== null && countdown > 0) {
         countdown--;
@@ -188,17 +188,17 @@
 </script>
 
 <style>
-  @keyframes subtle-scale {
+  @keyframes pulse-scale {
     0%, 100% {
       transform: translate(-50%, -50%) scale(1);
     }
     50% {
-      transform: translate(-50%, -50%) scale(1.1);
+      transform: translate(-50%, -50%) scale(1.15);
     }
   }
 
-  .subtle-animate {
-    animation: subtle-scale 2s ease-in-out infinite;
+  .pulse-scale {
+    animation: pulse-scale 1.5s ease-in-out infinite;
   }
 </style>
 
@@ -272,32 +272,31 @@
     {:else}
       <div class="flex flex-col gap-4">
         <p class="text-sm text-muted-foreground text-center">
-          Place your fingers on the screen. After 5 seconds, 2 fingers will be white team and 2 will be brown team.
+          Place your fingers on the screen. After 3 seconds, 2 fingers will be white team and 2 will be brown team.
         </p>
 
         <div
-          class="relative w-full h-[60vh] bg-muted rounded-lg overflow-hidden touch-none select-none"
+          class="relative w-full min-h-screen bg-muted touch-none select-none"
           ontouchstart={handleTouchStart}
           ontouchmove={handleTouchMove}
           ontouchend={handleTouchEnd}
         >
           {#each touches as touch (touch.identifier)}
             <div
-              class="absolute w-24 h-24 rounded-full flex items-center justify-center text-4xl transition-colors duration-500"
-              class:subtle-animate={countdown !== null}
-              class:bg-white={touch.color === 'white'}
-              class:text-black={touch.color === 'white'}
-              class:border-4={touch.color === 'white'}
-              class:border-black={touch.color === 'white'}
-              class:bg-amber-800={touch.color === 'brown'}
-              class:text-white={touch.color === 'brown'}
-              class:bg-gray-400={touch.color === null}
-              class:text-gray-700={touch.color === null}
+              class="absolute w-24 h-24 rounded-full transition-colors duration-500 shadow-lg border-4 flex items-center justify-center"
+              class:pulse-scale={countdown !== null}
+              class:border-white={touch.color === 'white'}
+              class:border-amber-900={touch.color === 'brown'}
+              class:border-gray-300={touch.color === null}
               style="left: {touch.x}px; top: {touch.y}px; transform: translate(-50%, -50%);"
             >
-              {#if touch.color}
-                {touch.color === 'white' ? '⚪' : '🟤'}
-              {/if}
+              <div
+                class="rounded-full transition-colors duration-500"
+                class:bg-white={touch.color === 'white'}
+                class:bg-amber-900={touch.color === 'brown'}
+                class:bg-gray-300={touch.color === null}
+                style="width: 72px; height: 72px;"
+              ></div>
             </div>
           {/each}
         </div>

--- a/frontend/src/routes/(authed)/random/+page.svelte
+++ b/frontend/src/routes/(authed)/random/+page.svelte
@@ -13,6 +13,9 @@
 
   let { data }: Props = $props();
 
+  type Tab = 'names' | 'touch';
+  let activeTab = $state<Tab>('names');
+
   let players = $state([
     data.players[0] ?? '',
     data.players[1] ?? '',
@@ -32,47 +35,273 @@
       );
     }
   }
+
+  interface Touch {
+    identifier: number;
+    x: number;
+    y: number;
+    color: 'white' | 'brown' | null;
+  }
+
+  let touches = $state<Touch[]>([]);
+  let countdown = $state<number | null>(null);
+  let countdownTimer: number | null = null;
+  let resetTimer: number | null = null;
+  let showingResult = $state(false);
+  let isMobile = $state(false);
+
+  $effect(() => {
+    if (browser) {
+      isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    }
+  });
+
+  function handleTouchStart(event: TouchEvent) {
+    event.preventDefault();
+
+    if (showingResult) {
+      return;
+    }
+
+    const rect = (event.target as HTMLElement).getBoundingClientRect();
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      const touch = event.changedTouches[i];
+      const x = touch.clientX - rect.left;
+      const y = touch.clientY - rect.top;
+
+      touches.push({
+        identifier: touch.identifier,
+        x,
+        y,
+        color: null,
+      });
+    }
+
+    resetCountdown();
+  }
+
+  function handleTouchMove(event: TouchEvent) {
+    event.preventDefault();
+    const rect = (event.target as HTMLElement).getBoundingClientRect();
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      const touch = event.changedTouches[i];
+      const existingTouch = touches.find(t => t.identifier === touch.identifier);
+
+      if (existingTouch) {
+        existingTouch.x = touch.clientX - rect.left;
+        existingTouch.y = touch.clientY - rect.top;
+      }
+    }
+  }
+
+  function handleTouchEnd(event: TouchEvent) {
+    event.preventDefault();
+
+    if (showingResult) {
+      return;
+    }
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      const touch = event.changedTouches[i];
+      const index = touches.findIndex(t => t.identifier === touch.identifier);
+
+      if (index !== -1) {
+        touches.splice(index, 1);
+      }
+    }
+  }
+
+  function resetCountdown() {
+    if (countdownTimer !== null) {
+      clearInterval(countdownTimer);
+    }
+    if (resetTimer !== null) {
+      clearTimeout(resetTimer);
+      resetTimer = null;
+    }
+
+    showingResult = false;
+    countdown = 5;
+    countdownTimer = setInterval(() => {
+      if (countdown !== null && countdown > 0) {
+        countdown--;
+        if (countdown === 0) {
+          assignColors();
+          if (countdownTimer !== null) {
+            clearInterval(countdownTimer);
+          }
+        }
+      }
+    }, 1000) as unknown as number;
+  }
+
+  function assignColors() {
+    const touchCount = touches.length;
+
+    if (touchCount === 0) {
+      countdown = null;
+      return;
+    }
+
+    const indices = touches.map((_, i) => i);
+    const shuffled = indices.sort(() => Math.random() - 0.5);
+
+    const whiteCount = Math.min(2, touchCount);
+    const brownCount = Math.min(2, Math.max(0, touchCount - 2));
+
+    for (let i = 0; i < whiteCount; i++) {
+      touches[shuffled[i]].color = 'white';
+    }
+
+    for (let i = 0; i < brownCount; i++) {
+      touches[shuffled[whiteCount + i]].color = 'brown';
+    }
+
+    touches = touches.filter(t => t.color !== null);
+
+    countdown = null;
+    showingResult = true;
+
+    if (resetTimer !== null) {
+      clearTimeout(resetTimer);
+    }
+    resetTimer = setTimeout(() => {
+      resetTouchRandomizer();
+    }, 5000) as unknown as number;
+  }
+
+  function resetTouchRandomizer() {
+    touches = [];
+    countdown = null;
+    showingResult = false;
+    if (countdownTimer !== null) {
+      clearInterval(countdownTimer);
+      countdownTimer = null;
+    }
+    if (resetTimer !== null) {
+      clearTimeout(resetTimer);
+      resetTimer = null;
+    }
+  }
 </script>
+
+<style>
+  @keyframes subtle-scale {
+    0%, 100% {
+      transform: translate(-50%, -50%) scale(1);
+    }
+    50% {
+      transform: translate(-50%, -50%) scale(1.1);
+    }
+  }
+
+  .subtle-animate {
+    animation: subtle-scale 2s ease-in-out infinite;
+  }
+</style>
 
 <div class="flex flex-col gap-8">
   <PageTitle>Random Team Generator</PageTitle>
-  <div class="grid grid-cols-2 gap-4">
-    {#each players as player, idx}
-      <div class="flex flex-col gap-2">
-        <Label for="player-{idx}">Player {idx + 1}</Label>
-        <Input id="player-{idx}" bind:value={players[idx]} />
-      </div>
-    {/each}
+
+  <div class="flex gap-2 border-b">
+    <button
+      class="px-4 py-2 transition-colors {activeTab === 'names'
+        ? 'border-b-2 border-primary font-semibold'
+        : 'text-muted-foreground hover:text-foreground'}"
+      onclick={() => activeTab = 'names'}
+    >
+      Names
+    </button>
+    <button
+      class="px-4 py-2 transition-colors {activeTab === 'touch'
+        ? 'border-b-2 border-primary font-semibold'
+        : 'text-muted-foreground hover:text-foreground'}"
+      onclick={() => activeTab = 'touch'}
+    >
+      Touch
+    </button>
   </div>
-  <Button
-    type="button"
-    disabled={players.some((p) => p == null || p.trim() === '')}
-    onclick={generateTeams}>Generate Teams</Button
-  >
-  {#if teams.length === 2}
-    <div class="flex flex-row gap-4 text-center">
-      <div class="flex flex-1 flex-col">
-        <h3 class="text-2xl">Team 1</h3>
-        <ul>
-          {#each teams[0] as player}
-            <li>{player}</li>
-          {/each}
-        </ul>
-      </div>
-      <div class="flex-s bg-border min-h-full w-px"></div>
-      <div class="flex flex-1 flex-col">
-        <h3 class="text-2xl">Team 2</h3>
-        <ul>
-          {#each teams[1] as player}
-            <li>{player}</li>
-          {/each}
-        </ul>
-      </div>
+
+  {#if activeTab === 'names'}
+    <div class="grid grid-cols-2 gap-4">
+      {#each players as player, idx}
+        <div class="flex flex-col gap-2">
+          <Label for="player-{idx}">Player {idx + 1}</Label>
+          <Input id="player-{idx}" bind:value={players[idx]} />
+        </div>
+      {/each}
     </div>
     <Button
-      href="/submit?player1={teams[0][0]}&player2={teams[0][1]}&player3={teams[1][0]}&player4={teams[1][1]}"
+      type="button"
+      disabled={players.some((p) => p == null || p.trim() === '')}
+      onclick={generateTeams}>Generate Teams</Button
     >
-      Submit result
-    </Button>
+    {#if teams.length === 2}
+      <div class="flex flex-row gap-4 text-center">
+        <div class="flex flex-1 flex-col">
+          <h3 class="text-2xl">Team 1</h3>
+          <ul>
+            {#each teams[0] as player}
+              <li>{player}</li>
+            {/each}
+          </ul>
+        </div>
+        <div class="flex-s bg-border min-h-full w-px"></div>
+        <div class="flex flex-1 flex-col">
+          <h3 class="text-2xl">Team 2</h3>
+          <ul>
+            {#each teams[1] as player}
+              <li>{player}</li>
+            {/each}
+          </ul>
+        </div>
+      </div>
+      <Button
+        href="/submit?player1={teams[0][0]}&player2={teams[0][1]}&player3={teams[1][0]}&player4={teams[1][1]}"
+      >
+        Submit result
+      </Button>
+    {/if}
+  {:else}
+    {#if !isMobile}
+      <div class="bg-muted p-4 rounded-lg text-center">
+        <p class="text-muted-foreground">This feature only works on mobile devices with touch support.</p>
+      </div>
+    {:else}
+      <div class="flex flex-col gap-4">
+        <p class="text-sm text-muted-foreground text-center">
+          Place your fingers on the screen. After 5 seconds, 2 fingers will be white team and 2 will be brown team.
+        </p>
+
+        <div
+          class="relative w-full h-[60vh] bg-muted rounded-lg overflow-hidden touch-none select-none"
+          ontouchstart={handleTouchStart}
+          ontouchmove={handleTouchMove}
+          ontouchend={handleTouchEnd}
+        >
+          {#each touches as touch (touch.identifier)}
+            <div
+              class="absolute w-24 h-24 rounded-full flex items-center justify-center text-4xl transition-colors duration-500"
+              class:subtle-animate={countdown !== null}
+              class:bg-white={touch.color === 'white'}
+              class:text-black={touch.color === 'white'}
+              class:border-4={touch.color === 'white'}
+              class:border-black={touch.color === 'white'}
+              class:bg-amber-800={touch.color === 'brown'}
+              class:text-white={touch.color === 'brown'}
+              class:bg-gray-400={touch.color === null}
+              class:text-gray-700={touch.color === null}
+              style="left: {touch.x}px; top: {touch.y}px; transform: translate(-50%, -50%);"
+            >
+              {#if touch.color}
+                {touch.color === 'white' ? '⚪' : '🟤'}
+              {/if}
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- Add touch-based randomizer interface for mobile team selection
- Implement visual bubble indicators with ring and inner circle design
- Require minimum 4 touches before countdown starts
- Auto-reset after team selection with 5 second display time

## Changes
- New "Touch" tab in random team generator with mobile-only functionality
- Countdown timer reduced from 5 to 3 seconds for faster selection
- Touch bubbles (96px total) with 4px border ring and 72px inner circle
- Color-coded results: white team and brown team assignments
- Pulsating animation during countdown for visual feedback
- Countdown only activates when at least 4 fingers are on screen

## Test plan
- [x] Verify touch interface only shows on mobile devices
- [x] Test with 4+ simultaneous touches - countdown should start
- [x] Test with <4 touches - countdown should not start
- [x] Remove finger during countdown - should cancel and reset
- [x] Verify team assignment shows white and brown colored bubbles
- [x] Check auto-reset after 5 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="590" height="1130" alt="https0hfwr910-5173 euw devtunnels msrandom" src="https://github.com/user-attachments/assets/bb3b47bd-86ef-4fbe-b8d5-cbb59a369c9c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-tab interface (Names, Touch) for the Random Team Generator.
  * Mobile touch-based randomizer with touch interactions, countdown, color assignment, and result display.
  * Preserved name-based input grid and Generate Teams flow.

* **Style**
  * Added pulse-scale animation for active touches and conditional mobile UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->