### PR TITLE
feat: highligh current player and divide leaderboard

### DIFF
--- a/frontend/src/lib/components/leaderboard/leaderboard.svelte
+++ b/frontend/src/lib/components/leaderboard/leaderboard.svelte
@@ -2,6 +2,7 @@
   import * as Card from '$lib/components/ui/card';
   import * as Table from '$lib/components/ui/table';
   import { SHOW_STREAK_THRESHOLD } from '$lib/constants';
+  import { cn } from '$lib/utils';
   import type { PlayerHistoryDetails, UserDetails } from '../../../api';
   import Sparkline from '../ui/sparkline/sparkline.svelte';
   import type { RankedLeaderboardEntry } from './leader-board-entry';
@@ -11,9 +12,11 @@
     users: UserDetails[] | null | undefined;
     onSelectedUser: (user: UserDetails) => void;
     statisticsPromise: Promise<PlayerHistoryDetails[]> | undefined;
+    currentUserId: number | undefined;
   }
 
-  let { data, users, onSelectedUser, statisticsPromise }: Props = $props();
+  let { data, users, onSelectedUser, statisticsPromise, currentUserId }: Props =
+    $props();
 </script>
 
 <Card.Root>
@@ -35,7 +38,13 @@
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {#each data as { userId, loses, name, wins, mmr, winningStreak, losingStreak, rank }}
+        {#each data as { userId, loses, name, wins, mmr, winningStreak, losingStreak, rank }, index}
+          {#if mmr == null && data[index - 1]?.mmr != null}
+            <Table.Row class="">
+              <Table.Cell colspan={5} class="text-center">Placement</Table.Cell>
+            </Table.Row>
+          {/if}
+
           {@const userDisplayName = users?.find(
             (user) => user.userId == userId
           )?.displayName}
@@ -49,9 +58,15 @@
               }
             }}
           >
-            <Table.Cell class="max-w-[3ch] font-bold">{rank}</Table.Cell>
+            <Table.Cell class="max-w-[3ch] font-bold"
+              >{mmr != null ? rank : '•'}</Table.Cell
+            >
             <Table.Cell class="max-w-[230px]">
-              <div class="flex flex-col items-start">
+              <div
+                class={cn('flex flex-col items-start', {
+                  'text-primary': currentUserId === userId,
+                })}
+              >
                 {#if userDisplayName != null}
                   <span class="hidden w-full truncate sm:block">
                     {userDisplayName}
@@ -75,7 +90,8 @@
                 {loses}
                 {#if losingStreak && losingStreak >= SHOW_STREAK_THRESHOLD}
                   <span class="text-nowrap text-xs" title="Losing streak">
-                    {losingStreak >= 7 ? '⛈️' : '🌧️'} <span class="hidden sm:inline">{losingStreak}</span>
+                    {losingStreak >= 7 ? '⛈️' : '🌧️'}
+                    <span class="hidden sm:inline">{losingStreak}</span>
                   </span>
                 {/if}
               </div>
@@ -104,7 +120,7 @@
                   </div>
                 {/if}
                 <span>
-                  {mmr ?? '🐣'}
+                  {mmr ?? `🐣`}
                 </span>
               </div>
             </Table.Cell>

--- a/frontend/src/lib/components/leaderboard/leaderboard.svelte
+++ b/frontend/src/lib/components/leaderboard/leaderboard.svelte
@@ -118,7 +118,7 @@
                   </div>
                 {/if}
                 <span>
-                  {mmr ?? `🐣`}
+                  {mmr ?? '🐣'}
                 </span>
               </div>
             </Table.Cell>

--- a/frontend/src/lib/components/leaderboard/leaderboard.svelte
+++ b/frontend/src/lib/components/leaderboard/leaderboard.svelte
@@ -49,7 +49,9 @@
             (user) => user.userId == userId
           )?.displayName}
           <Table.Row
-            class="cursor-pointer"
+            class={cn('cursor-pointer', {
+              'text-primary': currentUserId === userId,
+            })}
             tabindex={0}
             onclick={() => {
               const user = users?.find((user) => user.userId == userId);
@@ -62,11 +64,7 @@
               >{mmr != null ? rank : '•'}</Table.Cell
             >
             <Table.Cell class="max-w-[230px]">
-              <div
-                class={cn('flex flex-col items-start', {
-                  'text-primary': currentUserId === userId,
-                })}
-              >
+              <div class="flex flex-col items-start">
                 {#if userDisplayName != null}
                   <span class="hidden w-full truncate sm:block">
                     {userDisplayName}

--- a/frontend/src/lib/components/leaderboard/leaderboard.svelte
+++ b/frontend/src/lib/components/leaderboard/leaderboard.svelte
@@ -39,9 +39,9 @@
       </Table.Header>
       <Table.Body>
         {#each data as { userId, loses, name, wins, mmr, winningStreak, losingStreak, rank }, index}
-          {#if mmr == null && data[index - 1]?.mmr != null}
+          {#if mmr == null && (index === 0 || data[index - 1]?.mmr != null)}
             <Table.Row class="">
-              <Table.Cell colspan={5} class="text-center">Placement</Table.Cell>
+              <Table.Cell colspan={5} class="text-center">Unranked</Table.Cell>
             </Table.Row>
           {/if}
 

--- a/frontend/src/routes/(authed)/+page.svelte
+++ b/frontend/src/routes/(authed)/+page.svelte
@@ -101,6 +101,7 @@
       selectedUser = user;
     }}
     {statisticsPromise}
+    currentUserId={profile?.userId}
   />
 </div>
 <ActiveMatches activeMatches={activeMatches ?? []} users={users ?? []} />


### PR DESCRIPTION
* Highlight claimed user on leaderboard
* Remove rank for non-placed users
* Divide leaderboard into ranked and unranked players

<img width="1068" height="1839" alt="Screen Shot 2025-10-18 at 14 35 29" src="https://github.com/user-attachments/assets/87edde51-cdd6-4e4d-96b6-d45464742935" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leaderboard now highlights the current user's row for easy identification.
  * Shows a placement row for players without a match rating when appropriate.
  * Unranked players display a bullet instead of a numeric rank.
  * Losing-streak emoji moved before the count; the count is hidden on small screens.

* **Bug Fixes**
  * Ensured the rating fallback displays a stable friendly emoji.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->