### PR TITLE
Add close button to dialog

### DIFF
--- a/frontend/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/frontend/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -12,7 +12,7 @@
 
 <div
   class={cn(
-    'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+    'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
     className
   )}
   {...rest}

--- a/frontend/src/lib/components/user-stats-modal.svelte
+++ b/frontend/src/lib/components/user-stats-modal.svelte
@@ -54,11 +54,11 @@
 </script>
 
 <Dialog.Root {open} {onOpenChange}>
-  <Dialog.Content>
+  <Dialog.Content class="max-h-screen overflow-y-scroll">
     <Dialog.Title class="flex gap-2">
       {user.displayName ?? user.name}
     </Dialog.Title>
-    <Dialog.Description class="flex flex-col gap-4">
+    <div class="flex flex-col gap-4">
       {#if leaderboardEntry != null}
         {@const totalGamesPlayed =
           (leaderboardEntry.wins ?? 0) + (leaderboardEntry.loses ?? 0)}
@@ -110,9 +110,14 @@
           {/if}
         </div>
       {/if}
+    </div>
+    <Dialog.Footer class="gap-2">
+      <Button variant="outline" onclick={() => onOpenChange(false)}
+        >Close</Button
+      >
       <Button href={withSeasonParam(`/player/${user.userId}`, seasonId)}
         >More details</Button
       >
-    </Dialog.Description>
+    </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>

--- a/frontend/src/lib/components/user-stats-modal.svelte
+++ b/frontend/src/lib/components/user-stats-modal.svelte
@@ -54,7 +54,7 @@
 </script>
 
 <Dialog.Root {open} {onOpenChange}>
-  <Dialog.Content class="max-h-screen overflow-y-scroll">
+  <Dialog.Content class="max-h-screen overflow-y-auto">
     <Dialog.Title class="flex gap-2">
       {user.displayName ?? user.name}
     </Dialog.Title>


### PR DESCRIPTION
<img width="1056" height="1494" alt="Screen Shot 2025-10-18 at 15 01 18" src="https://github.com/user-attachments/assets/b766245e-3bd9-4621-a596-3643fc7321e8" />

<img width="2544" height="2139" alt="Screen Shot 2025-10-18 at 15 01 22" src="https://github.com/user-attachments/assets/87cee8da-e632-4fd8-92fe-fe67dbb44503" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Dialog content now scrolls when it exceeds screen height.
  * Close action moved into a dedicated dialog footer; More details remains in content.

* **Style**
  * Footer spacing updated for consistent gaps across responsive layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->