### PR TITLE
feat: responsive collapsible admin sidebar

### DIFF
--- a/frontend/src/routes/admin/+layout.svelte
+++ b/frontend/src/routes/admin/+layout.svelte
@@ -5,7 +5,9 @@
     ArrowLeft,
     ClipboardList,
     LayoutDashboard,
+    Menu,
     Users,
+    X,
   } from 'lucide-svelte';
   import '../../app.pcss';
   import type { LayoutData } from './$types';
@@ -13,6 +15,8 @@
 
   let { data, children }: { data: LayoutData; children: any } = $props();
   const { userRole } = data;
+
+  let sidebarOpen = $state(false);
 
   const navItems = [
     { href: '/admin', label: 'Dashboard', icon: LayoutDashboard },
@@ -39,10 +43,36 @@
 </script>
 
 <div class="bg-background text-foreground dark flex min-h-screen">
+  <!-- Mobile header -->
+  <div class="bg-card border-border fixed top-0 right-0 left-0 z-40 flex h-14 items-center border-b px-4 md:hidden">
+    <button
+      onclick={() => (sidebarOpen = !sidebarOpen)}
+      class="text-foreground rounded-lg p-2 hover:bg-accent"
+    >
+      {#if sidebarOpen}
+        <X class="h-5 w-5" />
+      {:else}
+        <Menu class="h-5 w-5" />
+      {/if}
+    </button>
+    <h2 class="text-foreground ml-2 text-lg font-bold">Admin Panel</h2>
+  </div>
+
+  <!-- Backdrop for mobile -->
+  {#if sidebarOpen}
+    <button
+      class="fixed inset-0 z-40 bg-black/50 md:hidden"
+      onclick={() => (sidebarOpen = false)}
+      aria-label="Close sidebar"
+    ></button>
+  {/if}
+
+  <!-- Sidebar -->
   <aside
-    class="border-border bg-card sticky top-0 flex h-screen w-64 flex-col border-r"
+    class="border-border bg-card fixed top-14 z-50 flex h-[calc(100vh-3.5rem)] w-64 flex-col border-r transition-transform duration-200 md:sticky md:top-0 md:z-auto md:h-screen md:translate-x-0
+      {sidebarOpen ? 'translate-x-0' : '-translate-x-full'}"
   >
-    <div class="border-border flex h-16 items-center border-b px-6">
+    <div class="border-border hidden h-16 items-center border-b px-6 md:flex">
       <h2 class="text-foreground text-xl font-bold">Admin Panel</h2>
     </div>
 
@@ -50,6 +80,7 @@
       {#each navItems as item}
         <a
           href={item.href}
+          onclick={() => (sidebarOpen = false)}
           class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors {isActive(
             item.href
           )
@@ -79,7 +110,7 @@
     </div>
   </aside>
 
-  <main class="flex-1 overflow-auto p-8">
+  <main class="mt-14 flex-1 overflow-auto p-4 md:mt-0 md:p-8">
     <div class="mx-auto max-w-7xl">
       {@render children()}
     </div>


### PR DESCRIPTION
## Summary
- Admin sidebar is now collapsible on mobile devices, starting in collapsed state
- Hamburger menu toggle in a fixed top header bar on small screens
- Expanded sidebar overlays content with a backdrop instead of pushing it aside
- Desktop layout remains unchanged

## Test plan
- [ ] Verify sidebar is collapsed by default on mobile viewport
- [ ] Verify hamburger menu toggles sidebar open/closed
- [ ] Verify backdrop closes sidebar when tapped
- [ ] Verify nav link clicks close the sidebar
- [ ] Verify desktop layout is unchanged (sidebar always visible, side-by-side)