### PR TITLE
fix: improve PWA experience with safe area handling

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -28,7 +28,10 @@
     <link rel="shortcut icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="msapplication-TileColor" content="#01182e" />
     <meta name="theme-color" content="#01182e" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="MMR Project" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/frontend/src/app.pcss
+++ b/frontend/src/app.pcss
@@ -58,9 +58,13 @@
   }
   body {
     @apply bg-background text-foreground;
+    padding-top: env(safe-area-inset-top);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
   }
 
   html {
     scroll-behavior: smooth;
+    overscroll-behavior: none;
   }
 }

--- a/frontend/src/lib/components/matchmaking/queued-state.svelte
+++ b/frontend/src/lib/components/matchmaking/queued-state.svelte
@@ -11,7 +11,7 @@
   let { matchMakingState, onLeaveQueue }: Props = $props();
 </script>
 
-<div class="fixed bottom-20 left-0 right-0 mx-auto max-w-screen-sm px-4">
+<div class="fixed left-0 right-0 mx-auto max-w-screen-sm px-4" style="bottom: calc(5rem + env(safe-area-inset-bottom))">
   <div
     class="animate-border w-full rounded-2xl border border border-transparent p-5 [background:linear-gradient(60deg,#001003,theme(colors.orange.950)_60%,#001003)_padding-box,conic-gradient(from_var(--border-angle),theme(colors.orange.600/.58)_80%,_theme(colors.orange.300)_94%,_theme(colors.orange.600/.58))_border-box]"
   >

--- a/frontend/src/lib/components/pull-to-refresh.svelte
+++ b/frontend/src/lib/components/pull-to-refresh.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { invalidateAll } from '$app/navigation';
+  import { RefreshCw } from 'lucide-svelte';
+
+  const THRESHOLD = 80;
+  const MAX_PULL = 120;
+  const DAMPING = 0.4;
+
+  let pullDistance = $state(0);
+  let isRefreshing = $state(false);
+  let startY = $state(0);
+  let isPulling = $state(false);
+
+  function isStandaloneMode(): boolean {
+    return (
+      window.matchMedia('(display-mode: standalone)').matches ||
+      (navigator as any).standalone === true
+    );
+  }
+
+  function onTouchStart(e: TouchEvent) {
+    if (window.scrollY !== 0 || isRefreshing || !isStandaloneMode()) return;
+    startY = e.touches[0].clientY;
+    isPulling = true;
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (!isPulling) return;
+    const deltaY = e.touches[0].clientY - startY;
+    if (deltaY < 0) {
+      pullDistance = 0;
+      return;
+    }
+    pullDistance = Math.min(deltaY * DAMPING, MAX_PULL);
+  }
+
+  async function onTouchEnd() {
+    if (!isPulling) return;
+    isPulling = false;
+
+    if (pullDistance >= THRESHOLD) {
+      isRefreshing = true;
+      pullDistance = THRESHOLD;
+      try {
+        await invalidateAll();
+      } finally {
+        isRefreshing = false;
+        pullDistance = 0;
+      }
+    } else {
+      pullDistance = 0;
+    }
+  }
+</script>
+
+<svelte:window
+  on:touchstart={onTouchStart}
+  on:touchmove={onTouchMove}
+  on:touchend={onTouchEnd}
+/>
+
+{#if pullDistance > 0}
+  <div
+    class="pointer-events-none fixed left-0 right-0 z-50 flex justify-center"
+    style="top: calc(env(safe-area-inset-top) + {pullDistance - 40}px); opacity: {Math.min(pullDistance / THRESHOLD, 1)}"
+  >
+    <div class="bg-card rounded-full border p-2 shadow-md">
+      <RefreshCw
+        class="text-primary h-6 w-6 {isRefreshing ? 'animate-spin' : ''}"
+        style="transform: rotate({(pullDistance / THRESHOLD) * 360}deg)"
+      />
+    </div>
+  </div>
+{/if}

--- a/frontend/src/routes/(authed)/+layout.svelte
+++ b/frontend/src/routes/(authed)/+layout.svelte
@@ -3,6 +3,7 @@
   import '../../app.pcss';
 
   import QueueIndicator from '$lib/components/matchmaking/queue-indicator.svelte';
+  import PullToRefresh from '$lib/components/pull-to-refresh.svelte';
   import type { Snippet } from 'svelte';
   import Navbar from './components/navbar.svelte';
   interface Props {
@@ -12,7 +13,8 @@
   let { children }: Props = $props();
 </script>
 
-<main class="mx-auto mb-16 max-w-screen-sm overflow-auto p-4">
+<PullToRefresh />
+<main class="mx-auto max-w-screen-sm overflow-auto p-4" style="margin-bottom: calc(4rem + env(safe-area-inset-bottom))">
   {@render children?.()}
 </main>
 <QueueIndicator />

--- a/frontend/src/routes/(authed)/components/active-matches.svelte
+++ b/frontend/src/routes/(authed)/components/active-matches.svelte
@@ -14,7 +14,7 @@
 </script>
 
 {#if activeMatches.length > 0}
-  <div class="fixed bottom-20 right-4">
+  <div class="fixed right-4" style="bottom: calc(5rem + env(safe-area-inset-bottom))">
     {#if !isExpanded}
       <button
         class="bg-background flex items-center gap-4 rounded-md border p-4 shadow-md"

--- a/frontend/src/routes/(authed)/components/navbar.svelte
+++ b/frontend/src/routes/(authed)/components/navbar.svelte
@@ -6,6 +6,7 @@
 
 <nav
   class="bg-card fixed bottom-0 left-0 right-0 flex w-screen flex-row justify-center border-t"
+  style="padding-bottom: env(safe-area-inset-bottom)"
 >
   <div
     class="flex w-full max-w-screen-sm flex-row items-center justify-stretch"

--- a/frontend/static/site.webmanifest
+++ b/frontend/static/site.webmanifest
@@ -1,6 +1,10 @@
 {
     "name": "MMR Project",
     "short_name": "MMR Project",
+    "id": "/",
+    "start_url": "/",
+    "scope": "/",
+    "orientation": "portrait",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
## Summary

- Adds `viewport-fit=cover` and Apple PWA meta tags so `env(safe-area-inset-*)` values are available
- Adds `padding-bottom: env(safe-area-inset-bottom)` to the navbar so it clears the iOS home indicator
- Adjusts main content bottom margin and floating elements (queue banner, active matches) to account for the taller navbar on notched devices
- Disables pinch-to-zoom (`maximum-scale=1, user-scalable=no`) and rubber-band overscroll (`overscroll-behavior: none`) in standalone mode
- Adds a pull-to-refresh component (only active in standalone PWA mode) since there's no browser chrome to refresh
- Adds `id`, `start_url`, `scope`, and `orientation` to the web manifest

Closes #45

## Test plan

- [ ] Open on an iPhone (or iOS simulator), add to Home Screen, and launch as PWA
- [ ] Verify the bottom navbar clears the home indicator on notched iPhones
- [ ] Verify no pinch-to-zoom getting stuck in standalone mode
- [ ] Verify pull-to-refresh works when scrolled to top in standalone mode
- [ ] Verify content doesn't render behind the status bar
- [ ] Verify no rubber-band overscroll bounce
- [ ] On desktop browser / non-notched device, verify no visual regressions (safe area values fall back to 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh functionality for seamlessly refreshing the app on mobile
  * Enhanced Progressive Web App (PWA) support with expanded manifest metadata

* **Style**
  * Improved mobile layout handling for devices with notches and safe display areas
  * Optimized touch and scroll behavior on mobile devices
  * Enhanced spacing and padding for proper display on notched devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->