### PR TITLE
fix: update @types/node to 25.5.0 in lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -296,6 +296,13 @@
         "fs-extra": "^8.1.0"
       }
     },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -387,11 +394,16 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -1233,6 +1245,15 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",


### PR DESCRIPTION
## Summary
Updates `package-lock.json` to fix the `release-pr` workflow failure caused by `@types/node` version mismatch.

**Root cause:** The lock file had `@types/node@12.20.55` at the top level, but `@inquirer/external-editor`, `vite`, and other dependencies require `@types/node@25.x`. When `npm ci` runs, it validates the lock file against the dependency tree and fails with:

```
npm error Invalid: lock file's @types/node@12.20.55 does not satisfy @types/node@25.5.0
npm error Missing: @types/node@12.20.55 from lock file
npm error Missing: undici-types@7.18.2 from lock file
```

**Fix:** Run `npm install` on main to regenerate the lock file. The top-level `@types/node` is updated to `25.5.0` and the missing `undici-types@7.18.2` dependency is added.

## Testing
- `npm ci` completes successfully after the fix
- All 104 packages audit cleanly (0 vulnerabilities)