### PR TITLE
chore(changeset): bump mmr-api to major to match frontend + api

### DIFF
--- a/.changeset/bump-mmr-api-major.md
+++ b/.changeset/bump-mmr-api-major.md
@@ -1,0 +1,8 @@
+---
+"mmr-api": major
+---
+
+Align mmr-api with the v3 release. The release script enforces a shared
+major across frontend, api, and mmr-api; without this bump the release
+PR job fails because frontend and api are moving to 1.0.0 while mmr-api
+would otherwise stay on 0.x. No behaviour changes in mmr-api itself.


### PR DESCRIPTION
## Summary
- The release-pr job [fails on main](https://github.com/office-rivals/mmr-project/actions/runs/25174713538/job/73803529451) because the v3 changeset bumps `frontend` and `api` to 1.0.0 while `mmr-api` stays on 0.1.0, and `scripts/release/version.mjs` enforces a shared major across all three components.
- Adds a `mmr-api: major` changeset so the next release PR can apply cleanly. No code change in `mmr-api`; this is a version-alignment chore.

## Test plan
- [ ] `release-pr` workflow on main succeeds after merge (no more "Release versions must share the same major" failure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata for the mmr-api package to align with the coordinated v3 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->