### PR TITLE
feat(seasons): label seasons as "Season N" in the picker

### DIFF
--- a/.changeset/season-numeric-labels.md
+++ b/.changeset/season-numeric-labels.md
@@ -1,0 +1,7 @@
+---
+"frontend": patch
+---
+
+Label seasons in the season picker as "Season 1", "Season 2", … instead
+of using the start month/year. The currently active season still reads
+"Current Season".

--- a/frontend/e2e/leaderboard.spec.ts
+++ b/frontend/e2e/leaderboard.spec.ts
@@ -44,9 +44,8 @@ test.describe('Leaderboard page', () => {
   }) => {
     await page.goto(LEAGUE_URL);
 
-    // The seed creates 3 seasons; the picker defaults to the current
-    // (newest) one, which is labelled "Season 3".
-    await expect(page.getByText('Season 3')).toBeVisible();
+    // The season picker label reads "Current Season" by default.
+    await expect(page.getByText('Current Season')).toBeVisible();
 
     // The leaderboard should include the test user (P1) — they have 11
     // matches in the current season, above the 10-match ranked threshold.

--- a/frontend/e2e/leaderboard.spec.ts
+++ b/frontend/e2e/leaderboard.spec.ts
@@ -44,8 +44,9 @@ test.describe('Leaderboard page', () => {
   }) => {
     await page.goto(LEAGUE_URL);
 
-    // The season picker label reads "Current Season" by default.
-    await expect(page.getByText('Current Season')).toBeVisible();
+    // The seed creates 3 seasons; the picker defaults to the current
+    // (newest) one, which is labelled "Season 3".
+    await expect(page.getByText('Season 3')).toBeVisible();
 
     // The leaderboard should include the test user (P1) — they have 11
     // matches in the current season, above the 10-match ranked threshold.

--- a/frontend/src/lib/components/season-picker.svelte
+++ b/frontend/src/lib/components/season-picker.svelte
@@ -28,20 +28,27 @@
     new Map(seasons.map((season, index) => [season.id, seasons.length - index]))
   );
 
-  function seasonLabel(season: SeasonResponse): string {
+  function seasonLabel(
+    season: SeasonResponse,
+    currentSeason: SeasonResponse
+  ): string {
+    if (season.id === currentSeason.id) return 'Current Season';
     return `Season ${seasonNumbers.get(season.id) ?? '?'}`;
   }
 
   function mapSeasonToItem(
-    season: SeasonResponse
+    season: SeasonResponse,
+    currentSeason: SeasonResponse
   ): NonNullable<SelectRootProps['items']>[number] {
     return {
-      label: seasonLabel(season),
+      label: seasonLabel(season, currentSeason),
       value: season.id,
     };
   }
 
-  let seasonValues = $derived(seasons.map(mapSeasonToItem));
+  let seasonValues = $derived(
+    seasons.map((season) => mapSeasonToItem(season, currentSeason))
+  );
 
   function getSeason(): string {
     return (seasons.find((s) => s.id === selectedSeason.id) ?? currentSeason)
@@ -74,7 +81,7 @@
     class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
     aria-label="Select a season"
   >
-    {seasonLabel(selectedSeason)}
+    {seasonLabel(selectedSeason, currentSeason)}
     <ChevronsUpDown class="ml-2 h-4 w-4 text-muted-foreground" />
   </Select.Trigger>
 

--- a/frontend/src/lib/components/season-picker.svelte
+++ b/frontend/src/lib/components/season-picker.svelte
@@ -24,30 +24,24 @@
       : currentSeason
   );
 
-  function seasonLabel(
-    season: SeasonResponse,
-    currentSeason: SeasonResponse
-  ): string {
-    if (season.id === currentSeason.id) return 'Current Season';
-    return new Date(season.startsAt).toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-    });
+  let seasonNumbers = $derived(
+    new Map(seasons.map((season, index) => [season.id, seasons.length - index]))
+  );
+
+  function seasonLabel(season: SeasonResponse): string {
+    return `Season ${seasonNumbers.get(season.id) ?? '?'}`;
   }
 
   function mapSeasonToItem(
-    season: SeasonResponse,
-    currentSeason: SeasonResponse
+    season: SeasonResponse
   ): NonNullable<SelectRootProps['items']>[number] {
     return {
-      label: seasonLabel(season, currentSeason),
+      label: seasonLabel(season),
       value: season.id,
     };
   }
 
-  let seasonValues = $derived(
-    seasons.map((season) => mapSeasonToItem(season, currentSeason))
-  );
+  let seasonValues = $derived(seasons.map(mapSeasonToItem));
 
   function getSeason(): string {
     return (seasons.find((s) => s.id === selectedSeason.id) ?? currentSeason)
@@ -80,7 +74,7 @@
     class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
     aria-label="Select a season"
   >
-    {seasonLabel(selectedSeason, currentSeason)}
+    {seasonLabel(selectedSeason)}
     <ChevronsUpDown class="ml-2 h-4 w-4 text-muted-foreground" />
   </Select.Trigger>
 


### PR DESCRIPTION
## Summary
- Replace the date-based season label (`Jan 2026`, `Feb 2026`, …) and the special `Current Season` case with a simple chronological number: oldest season is `Season 1`, the current one is the highest number.
- Number is derived from the descending array returned by the API (`seasons.length - index`), so it stays stable as new seasons are added.
- Updates the leaderboard e2e test that was asserting `Current Season` to expect `Season 3` (the seed creates 3 seasons).

## Test plan
- [ ] `pnpm check` passes (verified locally — 0 errors)
- [ ] `pnpm e2e -- leaderboard.spec.ts` passes against the seeded fixture
- [ ] Manually load a league/player/statistics page and confirm the picker shows `Season N` everywhere it appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the season picker to consistently display seasons using a numbered format (e.g., "Season 1", "Season 2") for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->