### PR TITLE
test(e2e): isolate e2e stack on dedicated ports

### DIFF
--- a/frontend/.env.e2e.example
+++ b/frontend/.env.e2e.example
@@ -12,12 +12,19 @@ E2E_USER_PASSWORD=bred6BAILEY@craziest
 #   psql -d mmr_project -c "SELECT identity_user_id FROM users WHERE email = '<email>'"
 E2E_IDENTITY_USER_ID=user_3AxNl1GZF7UG4Og7EzDoqwSVHo3
 
-# Database connection used by the seed script
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=mmr_project
-DB_USER=postgres
-DB_PASS=this_is_a_hard_password1337
+# The e2e suite runs on its own ports so it never collides with a local dev
+# stack (Postgres 5432, mmr-api 8080, .NET API 8081, Vite 5173). Defaults are
+# fine for almost everyone; override here only if these e2e ports are also
+# already taken on your machine.
+#
+# E2E_DB_HOST=localhost
+# E2E_DB_PORT=5433
+# E2E_DB_NAME=mmr_project
+# E2E_DB_USER=postgres
+# E2E_DB_PASS=this_is_a_hard_password1337
+# E2E_MMR_API_PORT=8090
+# E2E_API_PORT=8091
+# E2E_PORT=5180
 
-# Override base URL if your dev server runs on a different port
-# E2E_BASE_URL=http://localhost:5173
+# Override base URL if your e2e Vite server runs on a different port
+# E2E_BASE_URL=http://localhost:5180

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -21,30 +21,48 @@ npm run e2e:ui           # Playwright UI mode
 
 The runner orchestrates four moving pieces:
 
-1. `globalSetup` (`global-services.setup.ts`) starts the docker-compose
-   Postgres in `local-development/` and waits for the port to accept TCP
-   connections. Idempotent — running with the container already up is a
-   fast no-op.
+1. `globalSetup` (`global-services.setup.ts`) starts the e2e Postgres via
+   `local-development/docker-compose.e2e.yml` (a separate container with
+   its own volume) and waits for the port to accept TCP connections.
+   Idempotent — running with the container already up is a fast no-op.
 2. `webServer` entries in `playwright.config.ts` start the MMR API,
-   .NET API, and Vite dev server in parallel. Playwright blocks on each
-   one's HTTP probe URL before any tests run.
+   .NET API, and Vite dev server in parallel on dedicated e2e ports.
+   Playwright blocks on each one's HTTP probe URL before any tests run.
 3. The `setup` Playwright project (`global.setup.ts`) applies the
-   vendored seed (`scripts/seed-data.sql`) and signs into Clerk once,
-   saving the storage state for the rest of the suite.
+   vendored seed (`scripts/seed-data.sql`) against the e2e DB and signs
+   into Clerk once, saving the storage state for the rest of the suite.
 4. The `chromium` project runs every spec against the seeded fixture
    using that storage state.
 
-## Reusing already-running services
+## Port layout
 
-Locally, `reuseExistingServer: !process.env.CI` is the default. If you
-already have the API or Vite running in another terminal, Playwright
-will hit those processes instead of starting its own. CI always starts
-fresh.
+The e2e stack is fully isolated from local development. You can have
+your dev stack running and start `npm run e2e` without anything
+colliding.
 
-If a service won't start (port already taken by something incompatible,
-build error in the Go or .NET project), Playwright surfaces stdout from
-that command in the test output — look for the prefixed `[api]`,
-`[mmr-api]`, or `[frontend]` lines.
+| Service     | Local dev | e2e   | Override env var      |
+| ----------- | --------- | ----- | --------------------- |
+| Postgres    | 5432      | 5433  | `E2E_DB_PORT`         |
+| mmr-api     | 8080      | 8090  | `E2E_MMR_API_PORT`    |
+| .NET API    | 8081      | 8091  | `E2E_API_PORT`        |
+| Vite dev    | 5173      | 5180  | `E2E_PORT`            |
+
+The e2e Postgres data lives in a named docker volume (`mmr-e2e-db`) so
+EF migrations only run on first boot. To wipe the e2e DB completely:
+
+```bash
+cd local-development
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+## Why no service reuse
+
+E2E always starts fresh processes on its dedicated ports. Reusing an
+existing dev API or Vite server would point them at the wrong DB and
+the wrong API URL respectively. If a service won't start (port taken,
+build error), Playwright surfaces stdout from that command in the test
+output — look for the prefixed `[api]`, `[mmr-api]`, or `[frontend]`
+lines.
 
 ## Adding a new spec
 

--- a/frontend/e2e/global-services.setup.ts
+++ b/frontend/e2e/global-services.setup.ts
@@ -1,9 +1,11 @@
-// Boots the docker-compose Postgres before Playwright spins up its webServer
-// processes. We can't use Playwright's webServer.url probe for Postgres because
-// that's HTTP-only — we need TCP readiness against the postgres port.
+// Boots the e2e Postgres (separate container, separate port from local dev)
+// before Playwright spins up its webServer processes. We can't use Playwright's
+// webServer.url probe for Postgres because that's HTTP-only — we need TCP
+// readiness against the postgres port.
 //
-// CI runs this every time. Local devs typically already have docker-compose up,
-// in which case `docker compose up -d --wait` is a fast no-op.
+// The e2e stack uses local-development/docker-compose.e2e.yml, which exposes
+// Postgres on port 5433 with its own named volume. Local dev's stack on 5432
+// is untouched.
 
 import { execSync } from 'node:child_process';
 import net from 'node:net';
@@ -13,9 +15,10 @@ import { fileURLToPath } from 'node:url';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '../..');
 const composeDir = path.join(repoRoot, 'local-development');
+const composeFile = 'docker-compose.e2e.yml';
 
-const DB_HOST = process.env.DB_HOST ?? 'localhost';
-const DB_PORT = Number(process.env.DB_PORT ?? '5432');
+const DB_HOST = process.env.E2E_DB_HOST ?? 'localhost';
+const DB_PORT = Number(process.env.E2E_DB_PORT ?? '5433');
 const READY_TIMEOUT_MS = 60_000;
 
 async function waitForPort(host: string, port: number, timeoutMs: number) {
@@ -36,8 +39,8 @@ async function waitForPort(host: string, port: number, timeoutMs: number) {
     await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error(
-    `Postgres not reachable on ${host}:${port} after ${timeoutMs}ms — ` +
-      'is docker-compose running, or is another service squatting the port?'
+    `e2e Postgres not reachable on ${host}:${port} after ${timeoutMs}ms — ` +
+      `is docker-compose -f ${composeFile} running, or is another service squatting the port?`
   );
 }
 
@@ -50,16 +53,16 @@ export default async function globalSetup() {
     composeCmd = 'docker-compose';
   }
 
-  // Bring Postgres up if it isn't already. `up -d` is idempotent — already
-  // running containers stay running.
+  // Bring the e2e Postgres up if it isn't already. `up -d` is idempotent —
+  // already-running containers stay running.
   try {
-    execSync(`${composeCmd} up -d`, {
+    execSync(`${composeCmd} -f ${composeFile} up -d`, {
       cwd: composeDir,
       stdio: 'inherit',
     });
   } catch (error) {
     throw new Error(
-      `Failed to start docker-compose stack in ${composeDir}: ${
+      `Failed to start e2e docker-compose stack in ${composeDir}: ${
         (error as Error).message
       }`
     );

--- a/frontend/e2e/global.setup.ts
+++ b/frontend/e2e/global.setup.ts
@@ -22,10 +22,17 @@ setup('apply seed and sign in', async ({ page }) => {
   // 1. Reset DB to vendored seed, with the test user's Clerk identity.
   // execFileSync (with shell: false by default) bypasses shell parsing so
   // unusual characters in projectRoot can't be interpreted as commands.
+  // DB_HOST/DB_PORT are forced to the e2e Postgres (5433 by default) so
+  // we never accidentally seed against the local dev DB on 5432.
   execFileSync(path.join(projectRoot, 'scripts', 'seed-local.sh'), [], {
     stdio: 'inherit',
     env: {
       ...process.env,
+      DB_HOST: process.env.E2E_DB_HOST ?? 'localhost',
+      DB_PORT: process.env.E2E_DB_PORT ?? '5433',
+      DB_NAME: process.env.E2E_DB_NAME ?? 'mmr_project',
+      DB_USER: process.env.E2E_DB_USER ?? 'postgres',
+      DB_PASS: process.env.E2E_DB_PASS ?? 'this_is_a_hard_password1337',
       IDENTITY_USER_ID: identityUserId,
       USER_EMAIL: userEmail,
     },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,12 +11,30 @@ const repoRoot = path.resolve(here, '..');
 const apiDir = path.join(repoRoot, 'api/MMRProject.Api');
 const mmrApiDir = path.join(repoRoot, 'mmr-api');
 
-const PORT = process.env.E2E_PORT ?? '5173';
-const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
+// E2E runs on a parallel set of ports so it never collides with a local dev
+// stack (Postgres 5432, mmr-api 8080, .NET API 8081, Vite 5173). All four are
+// overridable via env vars for CI flexibility.
+const E2E_DB_HOST = process.env.E2E_DB_HOST ?? 'localhost';
+const E2E_DB_PORT = process.env.E2E_DB_PORT ?? '5433';
+const E2E_DB_NAME = process.env.E2E_DB_NAME ?? 'mmr_project';
+const E2E_DB_USER = process.env.E2E_DB_USER ?? 'postgres';
+const E2E_DB_PASS = process.env.E2E_DB_PASS ?? 'this_is_a_hard_password1337';
+const E2E_MMR_API_PORT = process.env.E2E_MMR_API_PORT ?? '8090';
+const E2E_API_PORT = process.env.E2E_API_PORT ?? '8091';
+const E2E_FRONTEND_PORT = process.env.E2E_PORT ?? '5180';
 
-// Devs typically run the dev servers themselves and want the e2e command to
-// reuse them; CI must always start fresh.
-const reuseExistingServer = !process.env.CI;
+const MMR_API_URL = `http://localhost:${E2E_MMR_API_PORT}`;
+const API_URL = `http://localhost:${E2E_API_PORT}`;
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${E2E_FRONTEND_PORT}`;
+
+const API_CONNECTION_STRING =
+  `Host=${E2E_DB_HOST};Port=${E2E_DB_PORT};` +
+  `Database=${E2E_DB_NAME};Username=${E2E_DB_USER};Password=${E2E_DB_PASS}`;
+
+// E2E ports are dedicated, so reusing an "existing server" makes no sense —
+// the only thing that could already be on those ports is a previous, possibly
+// stale, e2e run. Always start fresh.
+const reuseExistingServer = false;
 
 export default defineConfig({
   testDir: './e2e',
@@ -32,8 +50,9 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
-  // Boots Postgres via docker-compose before any webServer process tries to
-  // connect to it. Idempotent — re-running with services up is a fast no-op.
+  // Boots the e2e Postgres via docker-compose before any webServer process
+  // tries to connect to it. Idempotent — re-running with services up is a
+  // fast no-op.
   globalSetup: './e2e/global-services.setup.ts',
   // Each entry is started in parallel; Playwright waits on every URL before
   // running tests. The .NET API needs Postgres up first, which globalSetup
@@ -44,34 +63,51 @@ export default defineConfig({
       name: 'mmr-api',
       command: 'go run main.go',
       cwd: mmrApiDir,
-      url: 'http://localhost:8080/swagger/index.html',
+      url: `${MMR_API_URL}/swagger/index.html`,
       timeout: 60_000,
       reuseExistingServer,
       stdout: 'pipe',
       stderr: 'pipe',
+      env: {
+        MMR_API_PORT: E2E_MMR_API_PORT,
+      },
     },
     {
       // .NET API. Runs migrations on startup, so Postgres must be up.
+      // --no-launch-profile so launchSettings.json's hardcoded port 8081
+      // doesn't beat the ASPNETCORE_URLS env override below.
       name: 'api',
-      command: 'dotnet run',
+      command: 'dotnet run --no-launch-profile',
       cwd: apiDir,
-      url: 'http://localhost:8081/swagger/v3/swagger.json',
+      url: `${API_URL}/swagger/v3/swagger.json`,
       timeout: 180_000,
       reuseExistingServer,
       stdout: 'pipe',
       stderr: 'pipe',
+      env: {
+        ASPNETCORE_ENVIRONMENT: 'Development',
+        ASPNETCORE_URLS: API_URL,
+        ConnectionStrings__ApiDbContext: API_CONNECTION_STRING,
+        MMRCalculationAPI__BaseUrl: MMR_API_URL,
+      },
     },
     {
       // SvelteKit dev server. Calls into the .NET API via SSR for some routes,
       // so we want it up last — Playwright doesn't enforce ordering, but the
       // URL probe below blocks until the dev server actually serves a page.
       name: 'frontend',
-      command: 'npm run dev',
+      // --strictPort so a port collision surfaces a clear error instead of
+      // Vite silently sliding to the next free port (which Playwright would
+      // then never find).
+      command: `npm run dev -- --port ${E2E_FRONTEND_PORT} --strictPort`,
       url: `${BASE_URL}/login`,
       timeout: 60_000,
       reuseExistingServer,
       stdout: 'pipe',
       stderr: 'pipe',
+      env: {
+        API_BASE_PATH: API_URL,
+      },
     },
   ],
   projects: [

--- a/local-development/docker-compose.e2e.yml
+++ b/local-development/docker-compose.e2e.yml
@@ -1,0 +1,16 @@
+name: mmr-e2e
+
+services:
+  db-e2e:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: this_is_a_hard_password1337
+      POSTGRES_DB: mmr_project
+    ports:
+      - "5433:5432"
+    volumes:
+      - mmr-e2e-db:/var/lib/postgresql/data
+
+volumes:
+  mmr-e2e-db:

--- a/mmr-api/server/server.go
+++ b/mmr-api/server/server.go
@@ -1,6 +1,12 @@
 package server
 
+import "os"
+
 func Init() {
 	router := NewRouter()
-	router.Run(":8080")
+	port := os.Getenv("MMR_API_PORT")
+	if port == "" {
+		port = "8080"
+	}
+	router.Run(":" + port)
 }


### PR DESCRIPTION
## Summary

Run the e2e Postgres, mmr-api, .NET API, and Vite dev server on a parallel set of ports so a \`npm run e2e\` run can never collide with a local dev stack. You can keep your dev stack running and start the e2e suite without anything fighting over a port.

| Service     | Local dev | E2E   | Override env var      |
| ----------- | --------- | ----- | --------------------- |
| Postgres    | 5432      | 5433  | \`E2E_DB_PORT\`         |
| mmr-api     | 8080      | 8090  | \`E2E_MMR_API_PORT\`    |
| .NET API    | 8081      | 8091  | \`E2E_API_PORT\`        |
| Vite dev    | 5173      | 5180  | \`E2E_PORT\`            |

## What's in this PR

- **New \`local-development/docker-compose.e2e.yml\`** — dedicated Postgres container on 5433 with its own named volume \`mmr-e2e-db\` and project name \`mmr-e2e\` so it never sees the dev stack as orphans.
- **mmr-api** reads \`MMR_API_PORT\` env (default 8080) instead of the hardcoded \`:8080\` listen address.
- **playwright.config.ts** sets per-process env on every \`webServer\` entry so each child binds the right port and talks to the right upstream:
  - \`.NET API\` — \`ASPNETCORE_URLS\`, \`ConnectionStrings__ApiDbContext\`, \`MMRCalculationAPI__BaseUrl\`, \`ASPNETCORE_ENVIRONMENT=Development\`. Runs with \`--no-launch-profile\` so \`launchSettings.json\`'s hardcoded port 8081 doesn't beat the env override.
  - \`mmr-api\` — \`MMR_API_PORT\`.
  - \`Vite\` — \`API_BASE_PATH\` + \`--port --strictPort\` so port collisions surface as a clear error.
  - \`reuseExistingServer: false\` everywhere — reuse made no sense once each process needs e2e-specific env.
- **\`global.setup.ts\`** forces \`DB_HOST/DB_PORT/DB_NAME\` on the seed script so a stale \`.env.e2e\` can't redirect the seed at the dev DB.
- **\`global-services.setup.ts\`** boots the new compose file and waits on 5433.
- **README + .env.e2e.example** updated with the port table + isolation rationale.

## Test plan

- [x] \`docker compose -f docker-compose.e2e.yml up -d\` starts a Postgres on 5433 alongside the existing 5432 dev DB; \`docker ps\` shows both running with separate names.
- [x] \`npm run e2e -- leaderboard.spec.ts\` runs cold (boots all four services on the new ports) and passes.
- [ ] CI runs the full suite cleanly on the new ports.
- [ ] With a dev stack already running on 5432/8080/8081/5173, \`npm run e2e\` doesn't disrupt any of it.