### PR TITLE
fix(leaderboard): proxy report-match modal fetch through SvelteKit

### DIFF
--- a/.changeset/fix-report-match-modal.md
+++ b/.changeset/fix-report-match-modal.md
@@ -1,0 +1,5 @@
+---
+"frontend": patch
+---
+
+Fix the report-match modal on the leaderboard, which always rendered "Failed to load matches. Please try again." Add the missing SvelteKit endpoint at `/api/v3/organizations/[orgId]/leagues/[leagueId]/matches` that was assumed by the v3 modal rewrite.

--- a/frontend/e2e/leaderboard.spec.ts
+++ b/frontend/e2e/leaderboard.spec.ts
@@ -101,4 +101,27 @@ test.describe('Leaderboard page', () => {
     await expect(dialog.getByText('Rank')).toBeVisible();
     await expect(dialog.getByText('# Wins')).toBeVisible();
   });
+
+  test('opening the report-match modal loads recent matches', async ({
+    page,
+  }) => {
+    // Regression: the v3 rewrite of the modal pointed its client-side
+    // fetch at /api/v3/... but no SvelteKit endpoint matched that path,
+    // so every open showed "Failed to load matches".
+    await page.goto(LEAGUE_URL);
+
+    await page.getByRole('button', { name: 'Report match' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Report a match')).toBeVisible();
+
+    await expect(dialog.getByText('Failed to load matches')).toHaveCount(0);
+
+    // The seed has 15 current-season matches; at least one match button
+    // must render inside the dialog.
+    await expect(
+      dialog.locator('button.w-full.rounded-lg.border').first()
+    ).toBeVisible({ timeout: 10_000 });
+  });
 });

--- a/frontend/src/routes/api/v3/organizations/[orgId]/leagues/[leagueId]/matches/+server.ts
+++ b/frontend/src/routes/api/v3/organizations/[orgId]/leagues/[leagueId]/matches/+server.ts
@@ -1,0 +1,27 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// Browser-side proxy for the .NET API's GET /matches endpoint. The
+// report-match modal fetches this from the client; without this route
+// the request would 404 against the SvelteKit dev server because
+// handleFetch only intercepts server-side fetches.
+export const GET: RequestHandler = async ({
+  url,
+  params,
+  locals: { apiClientV3 },
+}) => {
+  const seasonId = url.searchParams.get('seasonId') ?? undefined;
+  const leaguePlayerId = url.searchParams.get('leaguePlayerId') ?? undefined;
+  const limitParam = url.searchParams.get('limit');
+  const offsetParam = url.searchParams.get('offset');
+  const limit = limitParam !== null ? Number(limitParam) : undefined;
+  const offset = offsetParam !== null ? Number(offsetParam) : undefined;
+
+  const matches = await apiClientV3.matchesApi.getMatches(
+    params.orgId,
+    params.leagueId,
+    { seasonId, leaguePlayerId, limit, offset }
+  );
+
+  return json(matches);
+};


### PR DESCRIPTION
## Summary

The v3 rewrite of \`report-match-modal.svelte\` points its client-side fetch at \`/api/v3/organizations/{orgId}/leagues/{leagueId}/matches\`. The .NET API serves that path, but the request goes to the SvelteKit dev server first — and there was no \`+server.ts\` matching it (\`handleFetch\` only intercepts server-side fetches). Result: SvelteKit returns its 404 page, \`response.ok\` is false, the modal renders **"Failed to load matches. Please try again."** every time.

This PR adds the missing endpoint as a thin proxy that calls \`locals.apiClientV3.matchesApi.getMatches(...)\` and returns JSON, matching the existing \`recent-match/+server.ts\` pattern.

## What's in this PR

- \`frontend/src/routes/api/v3/organizations/[orgId]/leagues/[leagueId]/matches/+server.ts\` (new) — forwards \`seasonId\`, \`leaguePlayerId\`, \`limit\`, \`offset\` query params to \`apiClientV3.matchesApi.getMatches\` and returns the array.
- \`frontend/e2e/leaderboard.spec.ts\` — new spec \`'opening the report-match modal loads recent matches'\` that opens the modal, asserts no error message, and asserts at least one match button is rendered. Catches this regression class going forward.

## Stacking

Based on **#226** (e2e port isolation) so the new e2e test runs cleanly on the dedicated ports. Will need a rebase onto \`main\` once #226 lands.

## Test plan

- [x] \`npm run e2e -- leaderboard.spec.ts -g \"report-match modal\"\` passes (14.4s, full webServer cold-boot included)
- [ ] Manual: open the leaderboard, click "Report match", confirm the modal lists recent matches instead of the error state
- [ ] Pagination works (Next/Previous buttons)