### PR TITLE
fix(api): apply season-transition soft reset on match calc and recalc

### DIFF
--- a/.changeset/season-transition-soft-reset.md
+++ b/.changeset/season-transition-soft-reset.md
@@ -2,15 +2,10 @@
 "api": patch
 ---
 
-Restore the season-transition soft reset for v3 match calculations. The
-first match a player plays in a new season is now flagged
-`IsPreviousSeasonRating` on the call to the MMR calculator, which collapses
-the player's mu 2/3 toward the default and resets sigma. The recorded delta
-for that first-of-season match is also forced to 0 so the leaderboard
-doesn't show a phantom swing on transition.
-
-Whole-season recalculation now resets each affected player to their most
-recent rating from a prior season (rather than absolute defaults), so the
-soft reset has the correct input on replay. Without this, replaying a
-season collapsed every player toward the new-player baseline regardless of
-their prior skill.
+Restore season-transition handling on the v3 match calc. The first match a
+player plays in a new season is now flagged `IsPreviousSeasonRating` on the
+calculator request, and its recorded delta is forced to 0 so the leaderboard
+doesn't show a phantom swing on transition. Whole-season recalc now resets
+each affected player to their most recent prior-season rating snapshot
+(rather than absolute defaults) before replaying, so the previous-season
+input reaches the calculator unchanged.

--- a/.changeset/season-transition-soft-reset.md
+++ b/.changeset/season-transition-soft-reset.md
@@ -1,0 +1,16 @@
+---
+"api": patch
+---
+
+Restore the season-transition soft reset for v3 match calculations. The
+first match a player plays in a new season is now flagged
+`IsPreviousSeasonRating` on the call to the MMR calculator, which collapses
+the player's mu 2/3 toward the default and resets sigma. The recorded delta
+for that first-of-season match is also forced to 0 so the leaderboard
+doesn't show a phantom swing on transition.
+
+Whole-season recalculation now resets each affected player to their most
+recent rating from a prior season (rather than absolute defaults), so the
+soft reset has the correct input on replay. Without this, replaying a
+season collapsed every player toward the new-player baseline regardless of
+their prior skill.

--- a/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
+++ b/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
@@ -109,25 +109,46 @@ public class StubMMRCalculationApiClient : IMMRCalculationApiClient
             Team1 = new MMRCalculationTeamResult
             {
                 Score = request.Team1.Score,
-                Players = request.Team1.Players.Select(p => new MMRCalculationPlayerResult
-                {
-                    Id = p.Id,
-                    Mu = (p.Mu ?? 25m) + (team1Delta / 100m),
-                    Sigma = Math.Max((p.Sigma ?? 8.333m) - 0.1m, 0.1m),
-                    MMR = (int)(1000 + Math.Round((((p.Mu ?? 25m) + (team1Delta / 100m)) - 25m) * 100m))
-                })
+                Players = request.Team1.Players.Select(p => BuildPlayerResult(p, team1Delta)),
             },
             Team2 = new MMRCalculationTeamResult
             {
                 Score = request.Team2.Score,
-                Players = request.Team2.Players.Select(p => new MMRCalculationPlayerResult
-                {
-                    Id = p.Id,
-                    Mu = (p.Mu ?? 25m) + (team2Delta / 100m),
-                    Sigma = Math.Max((p.Sigma ?? 8.333m) - 0.1m, 0.1m),
-                    MMR = (int)(1000 + Math.Round((((p.Mu ?? 25m) + (team2Delta / 100m)) - 25m) * 100m))
-                })
-            }
+                Players = request.Team2.Players.Select(p => BuildPlayerResult(p, team2Delta)),
+            },
+        };
+    }
+
+    // Mirrors the Go calculator's soft reset: when IsPreviousSeasonRating is true,
+    // the player's effective input becomes (mu - 25)/3 + 25, sigma=5 before the match
+    // delta is applied. Otherwise the provided mu/sigma are used as-is, falling back
+    // to defaults if either is missing.
+    private static MMRCalculationPlayerResult BuildPlayerResult(MMRCalculationPlayerRating p, int matchDelta)
+    {
+        decimal effectiveMu;
+        decimal effectiveSigma;
+
+        if (p.IsPreviousSeasonRating == true)
+        {
+            var inputMu = p.Mu ?? 25m;
+            effectiveMu = ((inputMu - 25m) / 3m) + 25m;
+            effectiveSigma = 5m;
+        }
+        else
+        {
+            effectiveMu = p.Mu ?? 25m;
+            effectiveSigma = p.Sigma ?? 8.333m;
+        }
+
+        var newMu = effectiveMu + (matchDelta / 100m);
+        var newSigma = Math.Max(effectiveSigma - 0.1m, 0.1m);
+
+        return new MMRCalculationPlayerResult
+        {
+            Id = p.Id,
+            Mu = newMu,
+            Sigma = newSigma,
+            MMR = (int)(1000 + Math.Round((newMu - 25m) * 100m)),
         };
     }
 }

--- a/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
+++ b/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
@@ -80,21 +80,33 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>
 
 public class StubMMRCalculationApiClient : IMMRCalculationApiClient
 {
+    private readonly List<MMRCalculationRequest> _requests = [];
+
     public bool ThrowOnCalculate { get; set; }
+
+    public IReadOnlyList<MMRCalculationRequest> Requests => _requests;
+
+    public void ResetRequests() => _requests.Clear();
 
     public Task<MMRCalculationResponse> CalculateMMRAsync(MMRCalculationRequest request)
     {
         if (ThrowOnCalculate)
             throw new InvalidOperationException("MMR calculation failed");
 
+        _requests.Add(request);
         return Task.FromResult(BuildResponse(request));
     }
 
     public Task<List<MMRCalculationResponse>> CalculateMMRBatchAsync(List<MMRCalculationRequest> requests)
     {
+        _requests.AddRange(requests);
         return Task.FromResult(requests.Select(BuildResponse).ToList());
     }
 
+    // Deterministic placeholder response. Tests should assert on the inputs the
+    // service passed (captured in Requests) and on what the service did with the
+    // response (delta=0 for first-of-season, etc.), NOT on the response shape —
+    // that's the real calculator's contract, not this stub's.
     private static MMRCalculationResponse BuildResponse(MMRCalculationRequest request)
     {
         var team1Delta = request.Team1.Score == request.Team2.Score
@@ -119,30 +131,12 @@ public class StubMMRCalculationApiClient : IMMRCalculationApiClient
         };
     }
 
-    // Mirrors the Go calculator's soft reset: when IsPreviousSeasonRating is true,
-    // the player's effective input becomes (mu - 25)/3 + 25, sigma=5 before the match
-    // delta is applied. Otherwise the provided mu/sigma are used as-is, falling back
-    // to defaults if either is missing.
     private static MMRCalculationPlayerResult BuildPlayerResult(MMRCalculationPlayerRating p, int matchDelta)
     {
-        decimal effectiveMu;
-        decimal effectiveSigma;
-
-        if (p.IsPreviousSeasonRating == true)
-        {
-            var inputMu = p.Mu ?? 25m;
-            effectiveMu = ((inputMu - 25m) / 3m) + 25m;
-            effectiveSigma = 5m;
-        }
-        else
-        {
-            effectiveMu = p.Mu ?? 25m;
-            effectiveSigma = p.Sigma ?? 8.333m;
-        }
-
-        var newMu = effectiveMu + (matchDelta / 100m);
-        var newSigma = Math.Max(effectiveSigma - 0.1m, 0.1m);
-
+        var inputMu = p.Mu ?? 25m;
+        var inputSigma = p.Sigma ?? 8.333m;
+        var newMu = inputMu + (matchDelta / 100m);
+        var newSigma = Math.Max(inputSigma - 0.1m, 0.1m);
         return new MMRCalculationPlayerResult
         {
             Id = p.Id,

--- a/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
+++ b/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
@@ -930,119 +930,118 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
     }
 
     [Fact]
-    public async Task SubmitMatch_FirstMatchOfNewSeason_AppliesSoftResetAndZeroDelta()
+    public async Task SubmitMatch_FirstMatchOfNewSeason_FlagsPreviousSeasonAndRecordsZeroDelta()
     {
         var org = await CreateOrganization();
         var league = await CreateLeague(org.Id);
-
-        // Past season, so the first batch of matches builds skill.
         await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow.AddDays(-90));
 
-        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+        var (_, _, p1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
             OrganizationRole.Owner);
-        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
-        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
-        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+        var (_, _, p2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, p3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, p4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+        Guid[] playerIds = [p1.Id, p2.Id, p3.Id, p4.Id];
 
         AuthenticateAs("p1");
 
-        // p1+p2 win three matches in the past season, building a clear skill edge.
-        for (var i = 0; i < 3; i++)
-        {
-            var response = await Client.PostAsJsonAsync(
-                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
-                new SubmitMatchRequest
-                {
-                    Teams =
-                    [
-                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
-                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
-                    ]
-                });
-            response.EnsureSuccessStatusCode();
-        }
+        // One past-season match so each player has a prior rating row.
+        var pastResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [p1.Id, p2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [p3.Id, p4.Id], Score = 5 }
+                ]
+            });
+        pastResponse.EnsureSuccessStatusCode();
 
-        decimal endOfSeasonMu;
-        decimal endOfSeasonSigma;
-        long endOfSeasonMmr;
+        // The lp values right now represent the end of the past season — what we
+        // expect the service to forward verbatim on the first new-season match.
+        Dictionary<Guid, (decimal Mu, decimal Sigma)> endOfPastSeasonByPlayer;
         using (var scope = Factory.Services.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
-            var lp = await dbContext.LeaguePlayers.FindAsync(player1.Id);
-            Assert.NotNull(lp);
-            endOfSeasonMu = lp!.Mu;
-            endOfSeasonSigma = lp.Sigma;
-            endOfSeasonMmr = lp.Mmr;
-
-            // Sanity: the past season's wins should have moved p1 above defaults.
-            Assert.True(endOfSeasonMu > 25m,
-                $"Expected end-of-past-season mu > 25, got {endOfSeasonMu}");
-            Assert.True(endOfSeasonSigma < 8m,
-                $"Expected end-of-past-season sigma < 8, got {endOfSeasonSigma}");
+            endOfPastSeasonByPlayer = (await dbContext.LeaguePlayers
+                .Where(lp => playerIds.Contains(lp.Id))
+                .ToListAsync())
+                .ToDictionary(lp => lp.Id, lp => (lp.Mu, lp.Sigma));
         }
 
-        // New season starts. Subsequent matches go into this season.
         await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow);
+        Factory.StubMmrCalculationApiClient.ResetRequests();
 
-        var firstNewSeasonResponse = await Client.PostAsJsonAsync(
+        var firstResponse = await Client.PostAsJsonAsync(
             $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
             new SubmitMatchRequest
             {
                 Teams =
                 [
-                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
-                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                    new SubmitMatchTeamRequest { Players = [p1.Id, p2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [p3.Id, p4.Id], Score = 5 }
                 ]
             });
-        firstNewSeasonResponse.EnsureSuccessStatusCode();
-        var firstNewSeasonMatch = await ReadJsonAsync<MatchResponse>(firstNewSeasonResponse);
-        Assert.NotNull(firstNewSeasonMatch);
+        firstResponse.EnsureSuccessStatusCode();
+        var firstMatch = await ReadJsonAsync<MatchResponse>(firstResponse);
+        Assert.NotNull(firstMatch);
 
+        // Exactly one calc request was sent — the new-season match.
+        Assert.Single(Factory.StubMmrCalculationApiClient.Requests);
+        var firstRequest = Factory.StubMmrCalculationApiClient.Requests[0];
+        var firstRequestPlayers = firstRequest.Team1.Players.Concat(firstRequest.Team2.Players).ToList();
+
+        // Every player was flagged as bringing a previous-season rating.
+        Assert.Equal(4, firstRequestPlayers.Count);
+        Assert.All(firstRequestPlayers, p => Assert.True(p.IsPreviousSeasonRating));
+
+        // The mu/sigma the service sent are the end-of-past-season state, not
+        // defaults — i.e. previous-season skill is carried forward to the calc.
+        var expectedMu = endOfPastSeasonByPlayer.Values.Select(v => v.Mu).OrderBy(x => x).ToArray();
+        var expectedSigma = endOfPastSeasonByPlayer.Values.Select(v => v.Sigma).OrderBy(x => x).ToArray();
+        var actualMu = firstRequestPlayers.Select(p => p.Mu!.Value).OrderBy(x => x).ToArray();
+        var actualSigma = firstRequestPlayers.Select(p => p.Sigma!.Value).OrderBy(x => x).ToArray();
+        Assert.Equal(expectedMu, actualMu);
+        Assert.Equal(expectedSigma, actualSigma);
+
+        // Recorded delta is 0 for the first-of-season match.
         using (var scope = Factory.Services.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
-
-            // Each player's first-of-new-season RatingHistory should have delta=0.
-            var newSeasonHistories = await dbContext.RatingHistories
-                .Where(rh => rh.MatchId == firstNewSeasonMatch!.Id)
+            var firstHistories = await dbContext.RatingHistories
+                .Where(rh => rh.MatchId == firstMatch!.Id)
                 .ToListAsync();
-            Assert.Equal(4, newSeasonHistories.Count);
-            Assert.All(newSeasonHistories, rh => Assert.Equal(0, rh.Delta));
-
-            // The soft reset should have collapsed mu 2/3 toward the default and reset
-            // sigma to ~5 before the calc ran. Match-delta is small relative to those
-            // changes, so we can assert on the order-of-magnitude.
-            var p1Reload = await dbContext.LeaguePlayers.FindAsync(player1.Id);
-            Assert.NotNull(p1Reload);
-            // sigma was below 8 at end of past season; after soft reset to 5 then one
-            // match's small decrease, expect ~4.9.
-            Assert.True(p1Reload!.Sigma < 5.5m && p1Reload.Sigma > 3m,
-                $"Expected post-soft-reset sigma in (3, 5.5), got {p1Reload.Sigma}");
-            // mu compressed: (endMu - 25)/3 + 25, then plus a small winner delta.
-            var expectedSoftResetMu = ((endOfSeasonMu - 25m) / 3m) + 25m;
-            Assert.True(Math.Abs(p1Reload.Mu - expectedSoftResetMu) < 1m,
-                $"Expected post-soft-reset mu near {expectedSoftResetMu}, got {p1Reload.Mu}");
+            Assert.Equal(4, firstHistories.Count);
+            Assert.All(firstHistories, rh => Assert.Equal(0, rh.Delta));
         }
 
-        // A second match in the new season should produce a normal (non-zero) delta.
-        var secondNewSeasonResponse = await Client.PostAsJsonAsync(
+        // A second match in the new season: the players now have current-season
+        // history, so the flag is no longer set and the recorded delta is non-zero.
+        Factory.StubMmrCalculationApiClient.ResetRequests();
+        var secondResponse = await Client.PostAsJsonAsync(
             $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
             new SubmitMatchRequest
             {
                 Teams =
                 [
-                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
-                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                    new SubmitMatchTeamRequest { Players = [p1.Id, p2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [p3.Id, p4.Id], Score = 5 }
                 ]
             });
-        secondNewSeasonResponse.EnsureSuccessStatusCode();
-        var secondNewSeasonMatch = await ReadJsonAsync<MatchResponse>(secondNewSeasonResponse);
+        secondResponse.EnsureSuccessStatusCode();
+        var secondMatch = await ReadJsonAsync<MatchResponse>(secondResponse);
+
+        Assert.Single(Factory.StubMmrCalculationApiClient.Requests);
+        var secondRequest = Factory.StubMmrCalculationApiClient.Requests[0];
+        Assert.All(secondRequest.Team1.Players.Concat(secondRequest.Team2.Players),
+            p => Assert.False(p.IsPreviousSeasonRating ?? false));
 
         using (var scope = Factory.Services.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
             var secondHistories = await dbContext.RatingHistories
-                .Where(rh => rh.MatchId == secondNewSeasonMatch!.Id)
+                .Where(rh => rh.MatchId == secondMatch!.Id)
                 .ToListAsync();
             Assert.Equal(4, secondHistories.Count);
             Assert.All(secondHistories, rh => Assert.NotEqual(0, rh.Delta));
@@ -1050,40 +1049,49 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
     }
 
     [Fact]
-    public async Task RecalculateMatches_WithoutFromMatchId_PreservesPreviousSeasonSkill()
+    public async Task RecalculateMatches_WholeSeasonReplay_FlagsFirstMatchOfNewSeason()
     {
         var org = await CreateOrganization();
         var league = await CreateLeague(org.Id);
-
         await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow.AddDays(-90));
 
-        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+        var (_, _, p1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
             OrganizationRole.Moderator);
-        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
-        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
-        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+        var (_, _, p2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, p3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, p4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+        Guid[] playerIds = [p1.Id, p2.Id, p3.Id, p4.Id];
 
         AuthenticateAs("p1");
 
-        // Build a past-season skill profile.
-        for (var i = 0; i < 3; i++)
+        // One past-season match.
+        var pastResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [p1.Id, p2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [p3.Id, p4.Id], Score = 5 }
+                ]
+            });
+        pastResponse.EnsureSuccessStatusCode();
+
+        // Snapshot each player's last past-season rating row — what the recalc
+        // reset should restore them to before the new-season replay starts.
+        Dictionary<Guid, (decimal Mu, decimal Sigma)> lastPastSeasonRating;
+        using (var scope = Factory.Services.CreateScope())
         {
-            var response = await Client.PostAsJsonAsync(
-                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
-                new SubmitMatchRequest
-                {
-                    Teams =
-                    [
-                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
-                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
-                    ]
-                });
-            response.EnsureSuccessStatusCode();
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+            lastPastSeasonRating = (await dbContext.LeaguePlayers
+                .Where(lp => playerIds.Contains(lp.Id))
+                .ToListAsync())
+                .ToDictionary(lp => lp.Id, lp => (lp.Mu, lp.Sigma));
         }
 
         await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow);
 
-        // Two matches in the new season.
+        // Two new-season matches.
         for (var i = 0; i < 2; i++)
         {
             var response = await Client.PostAsJsonAsync(
@@ -1092,47 +1100,61 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
                 {
                     Teams =
                     [
-                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
-                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                        new SubmitMatchTeamRequest { Players = [p1.Id, p2.Id], Score = 10 },
+                        new SubmitMatchTeamRequest { Players = [p3.Id, p4.Id], Score = 5 }
                     ]
                 });
             response.EnsureSuccessStatusCode();
         }
 
-        long mmrBeforeRecalc;
-        using (var scope = Factory.Services.CreateScope())
-        {
-            var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
-            var lp = await dbContext.LeaguePlayers.FindAsync(player1.Id);
-            mmrBeforeRecalc = lp!.Mmr;
-        }
+        Factory.StubMmrCalculationApiClient.ResetRequests();
 
-        // Whole-season recalc should produce the same end-state, NOT collapse to defaults.
+        // Whole-season recalc replays only the new-season matches.
         var recalcResponse = await Client.PostAsync(
             $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/recalculate",
             null);
         Assert.Equal(HttpStatusCode.OK, recalcResponse.StatusCode);
 
+        Assert.Equal(2, Factory.StubMmrCalculationApiClient.Requests.Count);
+
+        var firstReplay = Factory.StubMmrCalculationApiClient.Requests[0];
+        var firstReplayPlayers = firstReplay.Team1.Players.Concat(firstReplay.Team2.Players).ToList();
+
+        // First replayed match (the new season's first) was flagged, with input
+        // mu/sigma matching the players' end-of-past-season rating row — proves
+        // the reset carried previous-season skill forward instead of defaulting.
+        Assert.Equal(4, firstReplayPlayers.Count);
+        Assert.All(firstReplayPlayers, p => Assert.True(p.IsPreviousSeasonRating));
+
+        var expectedMu = lastPastSeasonRating.Values.Select(v => v.Mu).OrderBy(x => x).ToArray();
+        var expectedSigma = lastPastSeasonRating.Values.Select(v => v.Sigma).OrderBy(x => x).ToArray();
+        var actualMu = firstReplayPlayers.Select(p => p.Mu!.Value).OrderBy(x => x).ToArray();
+        var actualSigma = firstReplayPlayers.Select(p => p.Sigma!.Value).OrderBy(x => x).ToArray();
+        Assert.Equal(expectedMu, actualMu);
+        Assert.Equal(expectedSigma, actualSigma);
+
+        // Second replayed match: not flagged anymore.
+        var secondReplay = Factory.StubMmrCalculationApiClient.Requests[1];
+        Assert.All(secondReplay.Team1.Players.Concat(secondReplay.Team2.Players),
+            p => Assert.False(p.IsPreviousSeasonRating ?? false));
+
+        // First-of-season replay produces a delta=0 rating_histories row.
         using (var scope = Factory.Services.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
-            var lp = await dbContext.LeaguePlayers.FindAsync(player1.Id);
-            Assert.NotNull(lp);
-            // The replay must reproduce the same final MMR (deterministic stub +
-            // identical match sequence). This guarantees the previous-season skill
-            // was carried into the soft reset rather than wiped to defaults.
-            Assert.Equal(mmrBeforeRecalc, lp!.Mmr);
+            var newSeasonHistories = await dbContext.RatingHistories
+                .Join(dbContext.Set<V3Match>(), rh => rh.MatchId, m => m.Id, (rh, m) => new { rh, m })
+                .Where(x => x.m.LeagueId == league.Id)
+                .OrderBy(x => x.m.PlayedAt).ThenBy(x => x.m.RecordedAt).ThenBy(x => x.m.CreatedAt)
+                .Where(x => x.rh.LeaguePlayerId == p1.Id)
+                .Select(x => x.rh.Delta)
+                .ToListAsync();
 
-            // The new season's first match (chronologically) for p1 should have
-            // delta=0 in the recalculated rating_histories.
-            var firstNewSeasonHistory = await dbContext.RatingHistories
-                .Where(rh => rh.LeaguePlayerId == player1.Id)
-                .Join(dbContext.Set<V3Match>(), rh => rh.MatchId, m => m.Id,
-                    (rh, m) => new { rh, m })
-                .OrderByDescending(x => x.m.SeasonId)
-                .ThenBy(x => x.m.PlayedAt)
-                .FirstAsync();
-            Assert.Equal(0, firstNewSeasonHistory.rh.Delta);
+            // Past-season match (delta=0 because also first-ever match for p1) +
+            // two new-season matches. The first new-season delta must also be 0.
+            Assert.Equal(3, newSeasonHistories.Count);
+            Assert.Equal(0, newSeasonHistories[1]);
+            Assert.NotEqual(0, newSeasonHistories[2]);
         }
     }
 

--- a/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
+++ b/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
@@ -930,6 +930,213 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
     }
 
     [Fact]
+    public async Task SubmitMatch_FirstMatchOfNewSeason_AppliesSoftResetAndZeroDelta()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+
+        // Past season, so the first batch of matches builds skill.
+        await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow.AddDays(-90));
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Owner);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        // p1+p2 win three matches in the past season, building a clear skill edge.
+        for (var i = 0; i < 3; i++)
+        {
+            var response = await Client.PostAsJsonAsync(
+                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+                new SubmitMatchRequest
+                {
+                    Teams =
+                    [
+                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                    ]
+                });
+            response.EnsureSuccessStatusCode();
+        }
+
+        decimal endOfSeasonMu;
+        decimal endOfSeasonSigma;
+        long endOfSeasonMmr;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+            var lp = await dbContext.LeaguePlayers.FindAsync(player1.Id);
+            Assert.NotNull(lp);
+            endOfSeasonMu = lp!.Mu;
+            endOfSeasonSigma = lp.Sigma;
+            endOfSeasonMmr = lp.Mmr;
+
+            // Sanity: the past season's wins should have moved p1 above defaults.
+            Assert.True(endOfSeasonMu > 25m,
+                $"Expected end-of-past-season mu > 25, got {endOfSeasonMu}");
+            Assert.True(endOfSeasonSigma < 8m,
+                $"Expected end-of-past-season sigma < 8, got {endOfSeasonSigma}");
+        }
+
+        // New season starts. Subsequent matches go into this season.
+        await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow);
+
+        var firstNewSeasonResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                ]
+            });
+        firstNewSeasonResponse.EnsureSuccessStatusCode();
+        var firstNewSeasonMatch = await ReadJsonAsync<MatchResponse>(firstNewSeasonResponse);
+        Assert.NotNull(firstNewSeasonMatch);
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+
+            // Each player's first-of-new-season RatingHistory should have delta=0.
+            var newSeasonHistories = await dbContext.RatingHistories
+                .Where(rh => rh.MatchId == firstNewSeasonMatch!.Id)
+                .ToListAsync();
+            Assert.Equal(4, newSeasonHistories.Count);
+            Assert.All(newSeasonHistories, rh => Assert.Equal(0, rh.Delta));
+
+            // The soft reset should have collapsed mu 2/3 toward the default and reset
+            // sigma to ~5 before the calc ran. Match-delta is small relative to those
+            // changes, so we can assert on the order-of-magnitude.
+            var p1Reload = await dbContext.LeaguePlayers.FindAsync(player1.Id);
+            Assert.NotNull(p1Reload);
+            // sigma was below 8 at end of past season; after soft reset to 5 then one
+            // match's small decrease, expect ~4.9.
+            Assert.True(p1Reload!.Sigma < 5.5m && p1Reload.Sigma > 3m,
+                $"Expected post-soft-reset sigma in (3, 5.5), got {p1Reload.Sigma}");
+            // mu compressed: (endMu - 25)/3 + 25, then plus a small winner delta.
+            var expectedSoftResetMu = ((endOfSeasonMu - 25m) / 3m) + 25m;
+            Assert.True(Math.Abs(p1Reload.Mu - expectedSoftResetMu) < 1m,
+                $"Expected post-soft-reset mu near {expectedSoftResetMu}, got {p1Reload.Mu}");
+        }
+
+        // A second match in the new season should produce a normal (non-zero) delta.
+        var secondNewSeasonResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                ]
+            });
+        secondNewSeasonResponse.EnsureSuccessStatusCode();
+        var secondNewSeasonMatch = await ReadJsonAsync<MatchResponse>(secondNewSeasonResponse);
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+            var secondHistories = await dbContext.RatingHistories
+                .Where(rh => rh.MatchId == secondNewSeasonMatch!.Id)
+                .ToListAsync();
+            Assert.Equal(4, secondHistories.Count);
+            Assert.All(secondHistories, rh => Assert.NotEqual(0, rh.Delta));
+        }
+    }
+
+    [Fact]
+    public async Task RecalculateMatches_WithoutFromMatchId_PreservesPreviousSeasonSkill()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+
+        await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow.AddDays(-90));
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        // Build a past-season skill profile.
+        for (var i = 0; i < 3; i++)
+        {
+            var response = await Client.PostAsJsonAsync(
+                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+                new SubmitMatchRequest
+                {
+                    Teams =
+                    [
+                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                    ]
+                });
+            response.EnsureSuccessStatusCode();
+        }
+
+        await CreateSeason(org.Id, league.Id, DateTimeOffset.UtcNow);
+
+        // Two matches in the new season.
+        for (var i = 0; i < 2; i++)
+        {
+            var response = await Client.PostAsJsonAsync(
+                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+                new SubmitMatchRequest
+                {
+                    Teams =
+                    [
+                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                    ]
+                });
+            response.EnsureSuccessStatusCode();
+        }
+
+        long mmrBeforeRecalc;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+            var lp = await dbContext.LeaguePlayers.FindAsync(player1.Id);
+            mmrBeforeRecalc = lp!.Mmr;
+        }
+
+        // Whole-season recalc should produce the same end-state, NOT collapse to defaults.
+        var recalcResponse = await Client.PostAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/recalculate",
+            null);
+        Assert.Equal(HttpStatusCode.OK, recalcResponse.StatusCode);
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+            var lp = await dbContext.LeaguePlayers.FindAsync(player1.Id);
+            Assert.NotNull(lp);
+            // The replay must reproduce the same final MMR (deterministic stub +
+            // identical match sequence). This guarantees the previous-season skill
+            // was carried into the soft reset rather than wiped to defaults.
+            Assert.Equal(mmrBeforeRecalc, lp!.Mmr);
+
+            // The new season's first match (chronologically) for p1 should have
+            // delta=0 in the recalculated rating_histories.
+            var firstNewSeasonHistory = await dbContext.RatingHistories
+                .Where(rh => rh.LeaguePlayerId == player1.Id)
+                .Join(dbContext.Set<V3Match>(), rh => rh.MatchId, m => m.Id,
+                    (rh, m) => new { rh, m })
+                .OrderByDescending(x => x.m.SeasonId)
+                .ThenBy(x => x.m.PlayedAt)
+                .FirstAsync();
+            Assert.Equal(0, firstNewSeasonHistory.rh.Delta);
+        }
+    }
+
+    [Fact]
     public async Task RecalculateMatches_AsMember_Returns403()
     {
         var org = await CreateOrganization();

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -553,17 +553,61 @@ public class V3MatchesService(
         }
         else
         {
-            // Recalc from the start of the season — every affected player
-            // resets to defaults.
+            // Whole-season replay — reset every affected player to their
+            // most recent rating from a prior season. The first replayed
+            // match for each player will be flagged IsPreviousSeasonRating,
+            // and the calculator applies the soft reset (mu collapses
+            // 2/3 toward the default, sigma resets) at calc time.
+            // Players with no prior-season history fall back to defaults.
+            var preSeasonRatings = await dbContext.RatingHistories
+                .Where(rh => affectedPlayerIds.Contains(rh.LeaguePlayerId))
+                .Join(
+                    dbContext.Set<V3Match>(),
+                    rh => rh.MatchId,
+                    m => m.Id,
+                    (rh, m) => new
+                    {
+                        rh.LeaguePlayerId,
+                        rh.Mmr,
+                        rh.Mu,
+                        rh.Sigma,
+                        m.SeasonId,
+                        m.PlayedAt,
+                        m.RecordedAt,
+                        m.CreatedAt,
+                    })
+                .Where(x => x.SeasonId != currentSeason.Id)
+                .GroupBy(x => x.LeaguePlayerId)
+                .Select(g => g.OrderByDescending(x => x.PlayedAt)
+                              .ThenByDescending(x => x.RecordedAt)
+                              .ThenByDescending(x => x.CreatedAt)
+                              .First())
+                .ToDictionaryAsync(x => x.LeaguePlayerId);
+
             foreach (var lp in leaguePlayers)
             {
-                lp.Mmr = DefaultMmr;
-                lp.Mu = DefaultMu;
-                lp.Sigma = DefaultSigma;
+                if (preSeasonRatings.TryGetValue(lp.Id, out var snapshot))
+                {
+                    lp.Mmr = snapshot.Mmr;
+                    lp.Mu = snapshot.Mu;
+                    lp.Sigma = snapshot.Sigma;
+                }
+                else
+                {
+                    lp.Mmr = DefaultMmr;
+                    lp.Mu = DefaultMu;
+                    lp.Sigma = DefaultSigma;
+                }
             }
         }
 
         await dbContext.SaveChangesAsync();
+
+        // Track which players already have current-season history so the
+        // first replayed match for each of them gets flagged as a
+        // previous-season rating (delta=0, soft reset applied by calculator).
+        var playersWithCurrentSeasonHistory = await LoadPlayersWithSeasonHistoryAsync(
+            currentSeason.Id, affectedPlayerIds);
 
         // Replay in batches of 200 (matches v1 chunking) for fewer round trips
         // to the MMR calculation API.
@@ -572,7 +616,7 @@ public class V3MatchesService(
         for (var i = 0; i < matchesToReplay.Count; i += batchSize)
         {
             var batch = matchesToReplay.Skip(i).Take(batchSize).ToList();
-            await CalculateAndApplyMmrBatch(orgId, batch, leaguePlayerLookup);
+            await CalculateAndApplyMmrBatch(orgId, batch, leaguePlayerLookup, playersWithCurrentSeasonHistory);
         }
 
         return new RecalculateMatchesResponse
@@ -587,7 +631,8 @@ public class V3MatchesService(
     private async Task CalculateAndApplyMmrBatch(
         Guid orgId,
         List<V3Match> matches,
-        Dictionary<Guid, LeaguePlayer> leaguePlayerLookup)
+        Dictionary<Guid, LeaguePlayer> leaguePlayerLookup,
+        HashSet<Guid> playersWithCurrentSeasonHistory)
     {
         // Each match must be evaluated against the *previous* match's updated
         // ratings, so we have to walk sequentially. The chunking here only
@@ -618,8 +663,8 @@ public class V3MatchesService(
 
             var request = new MMRCalculationRequest
             {
-                Team1 = BuildTeam(teams[0], guidToIndex, leaguePlayerLookup),
-                Team2 = BuildTeam(teams[1], guidToIndex, leaguePlayerLookup),
+                Team1 = BuildTeam(teams[0], guidToIndex, leaguePlayerLookup, playersWithCurrentSeasonHistory),
+                Team2 = BuildTeam(teams[1], guidToIndex, leaguePlayerLookup, playersWithCurrentSeasonHistory),
             };
 
             var response = await mmrCalculationApiClient.CalculateMMRAsync(request);
@@ -631,7 +676,8 @@ public class V3MatchesService(
             foreach (var (leaguePlayerId, result) in playerResults)
             {
                 var lp = leaguePlayerLookup[leaguePlayerId];
-                var delta = result.MMR - lp.Mmr;
+                var isFirstMatchOfSeason = !playersWithCurrentSeasonHistory.Contains(leaguePlayerId);
+                var delta = isFirstMatchOfSeason ? 0 : result.MMR - lp.Mmr;
 
                 dbContext.Set<RatingHistory>().Add(new RatingHistory
                 {
@@ -647,6 +693,8 @@ public class V3MatchesService(
                 lp.Mmr = result.MMR;
                 lp.Mu = result.Mu;
                 lp.Sigma = result.Sigma;
+
+                playersWithCurrentSeasonHistory.Add(leaguePlayerId);
             }
         }
 
@@ -656,7 +704,8 @@ public class V3MatchesService(
     private static MMRCalculationTeam BuildTeam(
         MatchTeam team,
         Dictionary<Guid, long> guidToIndex,
-        Dictionary<Guid, LeaguePlayer> leaguePlayerLookup)
+        Dictionary<Guid, LeaguePlayer> leaguePlayerLookup,
+        HashSet<Guid> playersWithCurrentSeasonHistory)
     {
         return new MMRCalculationTeam
         {
@@ -669,9 +718,32 @@ public class V3MatchesService(
                     Id = guidToIndex[p.LeaguePlayerId],
                     Mu = lp.Mu,
                     Sigma = lp.Sigma,
+                    IsPreviousSeasonRating = !playersWithCurrentSeasonHistory.Contains(p.LeaguePlayerId),
                 };
             }).ToList(),
         };
+    }
+
+    private async Task<HashSet<Guid>> LoadPlayersWithSeasonHistoryAsync(
+        Guid seasonId,
+        IReadOnlyCollection<Guid> playerIds)
+    {
+        if (playerIds.Count == 0) return [];
+
+        var playerIdList = playerIds.ToList();
+        var seasonedIds = await dbContext.RatingHistories
+            .Where(rh => playerIdList.Contains(rh.LeaguePlayerId))
+            .Join(
+                dbContext.Set<V3Match>(),
+                rh => rh.MatchId,
+                m => m.Id,
+                (rh, m) => new { rh.LeaguePlayerId, m.SeasonId })
+            .Where(x => x.SeasonId == seasonId)
+            .Select(x => x.LeaguePlayerId)
+            .Distinct()
+            .ToListAsync();
+
+        return [.. seasonedIds];
     }
 
     private async Task<MatchResponse> LoadAndMapMatch(Guid orgId, Guid leagueId, Guid matchId)
@@ -696,19 +768,6 @@ public class V3MatchesService(
 
     private async Task CalculateAndApplyMmr(Guid orgId, V3Match match, List<LeaguePlayer> leaguePlayers)
     {
-        var playerMap = leaguePlayers.ToDictionary(lp => lp.Id);
-
-        // The MMR calculation API uses long IDs, so we create a mapping
-        var guidToIndex = new Dictionary<Guid, long>();
-        var indexToGuid = new Dictionary<long, Guid>();
-        long index = 1;
-        foreach (var player in leaguePlayers)
-        {
-            guidToIndex[player.Id] = index;
-            indexToGuid[index] = player.Id;
-            index++;
-        }
-
         var teams = match.Teams.OrderBy(t => t.Index).ToList();
         if (teams.Count != 2)
         {
@@ -716,36 +775,28 @@ public class V3MatchesService(
             return;
         }
 
+        var leaguePlayerLookup = leaguePlayers.ToDictionary(lp => lp.Id);
+        var playerIds = leaguePlayers.Select(lp => lp.Id).ToList();
+        var playersWithCurrentSeasonHistory = await LoadPlayersWithSeasonHistoryAsync(
+            match.SeasonId, playerIds);
+
+        var guidToIndex = new Dictionary<Guid, long>();
+        var indexToGuid = new Dictionary<long, Guid>();
+        long index = 1;
+        foreach (var team in teams)
+        {
+            foreach (var player in team.Players.OrderBy(p => p.Index))
+            {
+                guidToIndex[player.LeaguePlayerId] = index;
+                indexToGuid[index] = player.LeaguePlayerId;
+                index++;
+            }
+        }
+
         var mmrRequest = new MMRCalculationRequest
         {
-            Team1 = new MMRCalculationTeam
-            {
-                Score = teams[0].Score,
-                Players = teams[0].Players.Select(p =>
-                {
-                    var lp = playerMap[p.LeaguePlayerId];
-                    return new MMRCalculationPlayerRating
-                    {
-                        Id = guidToIndex[p.LeaguePlayerId],
-                        Mu = lp.Mu,
-                        Sigma = lp.Sigma,
-                    };
-                }),
-            },
-            Team2 = new MMRCalculationTeam
-            {
-                Score = teams[1].Score,
-                Players = teams[1].Players.Select(p =>
-                {
-                    var lp = playerMap[p.LeaguePlayerId];
-                    return new MMRCalculationPlayerRating
-                    {
-                        Id = guidToIndex[p.LeaguePlayerId],
-                        Mu = lp.Mu,
-                        Sigma = lp.Sigma,
-                    };
-                }),
-            },
+            Team1 = BuildTeam(teams[0], guidToIndex, leaguePlayerLookup, playersWithCurrentSeasonHistory),
+            Team2 = BuildTeam(teams[1], guidToIndex, leaguePlayerLookup, playersWithCurrentSeasonHistory),
         };
 
         MMRCalculationResponse mmrResponse;
@@ -765,9 +816,9 @@ public class V3MatchesService(
 
         foreach (var (leaguePlayerId, result) in playerResults)
         {
-            var leaguePlayer = playerMap[leaguePlayerId];
-            var previousMmr = leaguePlayer.Mmr;
-            var delta = result.MMR - previousMmr;
+            var leaguePlayer = leaguePlayerLookup[leaguePlayerId];
+            var isFirstMatchOfSeason = !playersWithCurrentSeasonHistory.Contains(leaguePlayerId);
+            var delta = isFirstMatchOfSeason ? 0 : result.MMR - leaguePlayer.Mmr;
 
             var ratingHistory = new RatingHistory
             {

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -553,12 +553,10 @@ public class V3MatchesService(
         }
         else
         {
-            // Whole-season replay — reset every affected player to their
-            // most recent rating from a prior season. The first replayed
-            // match for each player will be flagged IsPreviousSeasonRating,
-            // and the calculator applies the soft reset (mu collapses
-            // 2/3 toward the default, sigma resets) at calc time.
-            // Players with no prior-season history fall back to defaults.
+            // Whole-season replay — snap every affected player to their most
+            // recent prior-season rating snapshot (or defaults if none). The
+            // calculator decides what to do with previous-season inputs; this
+            // service only carries them forward.
             var preSeasonRatings = await dbContext.RatingHistories
                 .Where(rh => affectedPlayerIds.Contains(rh.LeaguePlayerId))
                 .Join(
@@ -603,9 +601,9 @@ public class V3MatchesService(
 
         await dbContext.SaveChangesAsync();
 
-        // Track which players already have current-season history so the
-        // first replayed match for each of them gets flagged as a
-        // previous-season rating (delta=0, soft reset applied by calculator).
+        // Drives the IsPreviousSeasonRating flag on each replayed match: a
+        // player not in this set when their match runs is treated as making
+        // their first appearance of the season.
         var playersWithCurrentSeasonHistory = await LoadPlayersWithSeasonHistoryAsync(
             currentSeason.Id, affectedPlayerIds);
 

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -728,9 +728,8 @@ public class V3MatchesService(
     {
         if (playerIds.Count == 0) return [];
 
-        var playerIdList = playerIds.ToList();
         var seasonedIds = await dbContext.RatingHistories
-            .Where(rh => playerIdList.Contains(rh.LeaguePlayerId))
+            .Where(rh => playerIds.Contains(rh.LeaguePlayerId))
             .Join(
                 dbContext.Set<V3Match>(),
                 rh => rh.MatchId,


### PR DESCRIPTION
## Summary

The v3 match service never set `IsPreviousSeasonRating` on the calls to the calculator, and the whole-season recalc reset every affected player to absolute defaults `(1500/25/8.333)` — which together produced large phantom rating swings on the first match of every season and squashed every player's rating toward the new-player baseline whenever the season was recalculated. Both behaviors existed in the v1/v2 service that v3 replaced; this PR restores them.

## What changed

- **Match submission** (`CalculateAndApplyMmr`) and **recalc** (`CalculateAndApplyMmrBatch`) now compute, per match and per player, whether the player has any `rating_histories` row in this match's season strictly earlier than this match. If not, the player is flagged `IsPreviousSeasonRating = true` on the request, and the recorded `delta` is forced to `0` so the leaderboard doesn't show a phantom swing on transition. What the calculator does with the flag is its concern; this service just stamps it.
- **Whole-season recalc** (`RecalculateCurrentSeasonAsync`'s no-`fromMatchId` branch) resets each affected player to their most recent `rating_histories` snapshot from a *prior* season (falling back to defaults only when no prior-season history exists). The first match of the season then replays with the previous-season input intact rather than zeroed out.
- **`BuildTeam` / `LoadPlayersWithSeasonHistoryAsync`**: small refactor — single helper that builds an `MMRCalculationTeam` with the per-player flag stamped on it, and a query that loads the set of players who already have current-season history. The submission and recalc paths now share both.

## Tests

- `StubMMRCalculationApiClient` now captures every received request (and returns a deterministic placeholder response). It deliberately doesn't mimic any calculator behavior so tests stay anchored to the service's contract rather than the calculator's.
- New `SubmitMatch_FirstMatchOfNewSeason_FlagsPreviousSeasonAndRecordsZeroDelta`: builds a past-season match, opens a new season, submits — asserts the captured calc request has `IsPreviousSeasonRating = true` for every player and that the `mu/sigma` the service sent match the players' end-of-past-season state (i.e., previous-season skill is carried forward, not zeroed). Recorded delta is asserted as 0. Second match in the new season has neither.
- New `RecalculateMatches_WholeSeasonReplay_FlagsFirstMatchOfNewSeason`: cross-season match sequence, runs whole-season recalc, asserts the first replayed (new-season) match's captured request has the flag set and `mu/sigma` matching the snapshotted last-prior-season values. The second replayed match has the flag clear.
- All 116 integration tests pass.

## Test plan

- [x] Integration tests for first-of-season flag + delta=0
- [x] Integration test for whole-season recalc carrying previous-season state forward
- [x] All existing match tests still pass
- [ ] Run a fresh whole-season recalc against the live data after this lands — the current `rating_histories` for the active season was written by the no-soft-reset replay and needs another pass to be correct