### PR TITLE
fix(matches): use batch MMR endpoint for v3 season recalc

### DIFF
--- a/.changeset/v3-batch-mmr-recalc.md
+++ b/.changeset/v3-batch-mmr-recalc.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Restore batch MMR endpoint usage in v3 season recalculations. v3 had regressed to one HTTP call per match; this rebuilds the chunk into a single batch request and aborts the recalc if the response count doesn't match, preventing half-applied recalculations.

--- a/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
+++ b/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
@@ -81,15 +81,38 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>
 public class StubMMRCalculationApiClient : IMMRCalculationApiClient
 {
     private readonly List<MMRCalculationRequest> _requests = [];
+    private readonly List<int> _batchSizes = [];
+    private int _singleCallCount;
+    private int _batchCallCount;
 
     public bool ThrowOnCalculate { get; set; }
 
+    /// When set, batch calls return this many responses regardless of request count.
+    /// Used to exercise the count-mismatch failure path.
+    public int? BatchResponseCountOverride { get; set; }
+
     public IReadOnlyList<MMRCalculationRequest> Requests => _requests;
 
-    public void ResetRequests() => _requests.Clear();
+    public int SingleCallCount => _singleCallCount;
+    public int BatchCallCount => _batchCallCount;
+    public IReadOnlyList<int> BatchSizes => _batchSizes;
+
+    public void ResetRequests()
+    {
+        lock (_requests) _requests.Clear();
+    }
+
+    public void ResetCallCounters()
+    {
+        Interlocked.Exchange(ref _singleCallCount, 0);
+        Interlocked.Exchange(ref _batchCallCount, 0);
+        lock (_batchSizes) _batchSizes.Clear();
+    }
 
     public Task<MMRCalculationResponse> CalculateMMRAsync(MMRCalculationRequest request)
     {
+        Interlocked.Increment(ref _singleCallCount);
+
         if (ThrowOnCalculate)
             throw new InvalidOperationException("MMR calculation failed");
 
@@ -99,8 +122,53 @@ public class StubMMRCalculationApiClient : IMMRCalculationApiClient
 
     public Task<List<MMRCalculationResponse>> CalculateMMRBatchAsync(List<MMRCalculationRequest> requests)
     {
+        Interlocked.Increment(ref _batchCallCount);
+        lock (_batchSizes) _batchSizes.Add(requests.Count);
+
         _requests.AddRange(requests);
-        return Task.FromResult(requests.Select(BuildResponse).ToList());
+
+        // Mirror the real mmr-api batch endpoint's carry-forward semantic: a
+        // player's first appearance uses the request mu/sigma; subsequent
+        // appearances inherit the previous match's output for the same Id.
+        var carry = new Dictionary<long, (decimal Mu, decimal Sigma)>();
+        var responses = requests.Select(req => BuildBatchResponse(req, carry)).ToList();
+
+        if (BatchResponseCountOverride is { } cap)
+        {
+            responses = responses.Take(cap).ToList();
+        }
+        return Task.FromResult(responses);
+    }
+
+    private static MMRCalculationResponse BuildBatchResponse(
+        MMRCalculationRequest request,
+        Dictionary<long, (decimal Mu, decimal Sigma)> carry)
+    {
+        MMRCalculationPlayerRating WithCarry(MMRCalculationPlayerRating p) =>
+            carry.TryGetValue(p.Id, out var s)
+                ? new MMRCalculationPlayerRating { Id = p.Id, Mu = s.Mu, Sigma = s.Sigma }
+                : p;
+
+        var carriedRequest = new MMRCalculationRequest
+        {
+            Team1 = new MMRCalculationTeam
+            {
+                Score = request.Team1.Score,
+                Players = request.Team1.Players.Select(WithCarry).ToList(),
+            },
+            Team2 = new MMRCalculationTeam
+            {
+                Score = request.Team2.Score,
+                Players = request.Team2.Players.Select(WithCarry).ToList(),
+            },
+        };
+
+        var response = BuildResponse(carriedRequest);
+        foreach (var pr in response.Team1.Players.Concat(response.Team2.Players))
+        {
+            carry[pr.Id] = (pr.Mu, pr.Sigma);
+        }
+        return response;
     }
 
     // Deterministic placeholder response. Tests should assert on the inputs the

--- a/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
+++ b/api/MMRProject.Api.IntegrationTests/Fixtures/IntegrationTestFactory.cs
@@ -97,21 +97,18 @@ public class StubMMRCalculationApiClient : IMMRCalculationApiClient
     public int BatchCallCount => _batchCallCount;
     public IReadOnlyList<int> BatchSizes => _batchSizes;
 
-    public void ResetRequests()
-    {
-        lock (_requests) _requests.Clear();
-    }
+    public void ResetRequests() => _requests.Clear();
 
     public void ResetCallCounters()
     {
-        Interlocked.Exchange(ref _singleCallCount, 0);
-        Interlocked.Exchange(ref _batchCallCount, 0);
-        lock (_batchSizes) _batchSizes.Clear();
+        _singleCallCount = 0;
+        _batchCallCount = 0;
+        _batchSizes.Clear();
     }
 
     public Task<MMRCalculationResponse> CalculateMMRAsync(MMRCalculationRequest request)
     {
-        Interlocked.Increment(ref _singleCallCount);
+        _singleCallCount++;
 
         if (ThrowOnCalculate)
             throw new InvalidOperationException("MMR calculation failed");
@@ -122,8 +119,8 @@ public class StubMMRCalculationApiClient : IMMRCalculationApiClient
 
     public Task<List<MMRCalculationResponse>> CalculateMMRBatchAsync(List<MMRCalculationRequest> requests)
     {
-        Interlocked.Increment(ref _batchCallCount);
-        lock (_batchSizes) _batchSizes.Add(requests.Count);
+        _batchCallCount++;
+        _batchSizes.Add(requests.Count);
 
         _requests.AddRange(requests);
 

--- a/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
+++ b/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
@@ -1159,6 +1159,97 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
     }
 
     [Fact]
+    public async Task RecalculateMatches_UsesBatchEndpoint()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+        await CreateSeason(org.Id, league.Id);
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        const int matchCount = 5;
+        for (var i = 0; i < matchCount; i++)
+        {
+            var response = await Client.PostAsJsonAsync(
+                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+                new SubmitMatchRequest
+                {
+                    Teams =
+                    [
+                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                    ]
+                });
+            response.EnsureSuccessStatusCode();
+        }
+
+        // Match submissions use the single endpoint; counters track recalc only.
+        Factory.StubMmrCalculationApiClient.ResetCallCounters();
+
+        var recalcResponse = await Client.PostAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/recalculate",
+            null);
+        recalcResponse.EnsureSuccessStatusCode();
+
+        Assert.Equal(0, Factory.StubMmrCalculationApiClient.SingleCallCount);
+        Assert.Equal(1, Factory.StubMmrCalculationApiClient.BatchCallCount);
+        Assert.Equal([matchCount], Factory.StubMmrCalculationApiClient.BatchSizes);
+    }
+
+    [Fact]
+    public async Task RecalculateMatches_AbortsWhenBatchResponseCountMismatches()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+        await CreateSeason(org.Id, league.Id);
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                ]
+            });
+        submitResponse.EnsureSuccessStatusCode();
+
+        Factory.StubMmrCalculationApiClient.ResetCallCounters();
+        Factory.StubMmrCalculationApiClient.BatchResponseCountOverride = 0;
+        try
+        {
+            var recalcResponse = await Client.PostAsync(
+                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/recalculate",
+                null);
+
+            // Surfaces as 500 — preferable to a silent 200 that leaves the DB
+            // half-recalculated and the next batch starting from stale state.
+            Assert.Equal(HttpStatusCode.InternalServerError, recalcResponse.StatusCode);
+            Assert.Equal(1, Factory.StubMmrCalculationApiClient.BatchCallCount);
+        }
+        finally
+        {
+            Factory.StubMmrCalculationApiClient.BatchResponseCountOverride = null;
+            Factory.StubMmrCalculationApiClient.ResetCallCounters();
+        }
+    }
+
+    [Fact]
     public async Task RecalculateMatches_AsMember_Returns403()
     {
         var org = await CreateOrganization();

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -633,10 +633,26 @@ public class V3MatchesService(
         HashSet<Guid> playersWithCurrentSeasonHistory)
     {
         // Each match must be evaluated against the *previous* match's updated
-        // ratings, so we have to walk sequentially. The chunking here only
-        // bounds how many SaveChangesAsync calls we make per outer caller.
-        // The MMR API is keyed on long IDs, so we use a per-match int counter
-        // since IDs only need to be unique within a single request.
+        // ratings. The MMR API's batch endpoint preserves that carry-forward
+        // semantic via its internal player map keyed on player.Id, so we send
+        // the entire chunk as a single request to cut HTTP round-trips.
+        // The MMR API is keyed on long IDs, so we assign a stable long per
+        // LeaguePlayer for the duration of the batch — the API then ignores
+        // mu/sigma/IsPreviousSeasonRating on subsequent appearances and uses
+        // the carried-forward state instead.
+        var guidToId = new Dictionary<Guid, long>();
+        var idToGuid = new Dictionary<long, Guid>();
+        long nextId = 1;
+
+        // playersWithCurrentSeasonHistory captures the state at batch start; it
+        // only gets mutated when we apply responses below. To set
+        // IsPreviousSeasonRating correctly per-match while building requests up
+        // front, virtually track in-batch first appearances here.
+        var seenInBatch = new HashSet<Guid>(playersWithCurrentSeasonHistory);
+
+        var validMatches = new List<V3Match>(matches.Count);
+        var requests = new List<MMRCalculationRequest>(matches.Count);
+
         foreach (var match in matches)
         {
             var teams = match.Teams.OrderBy(t => t.Index).ToList();
@@ -646,30 +662,61 @@ public class V3MatchesService(
                 continue;
             }
 
-            var guidToIndex = new Dictionary<Guid, long>();
-            var indexToGuid = new Dictionary<long, Guid>();
-            long index = 1;
             foreach (var team in teams)
             {
                 foreach (var player in team.Players.OrderBy(p => p.Index))
                 {
-                    guidToIndex[player.LeaguePlayerId] = index;
-                    indexToGuid[index] = player.LeaguePlayerId;
-                    index++;
+                    if (guidToId.ContainsKey(player.LeaguePlayerId)) continue;
+                    guidToId[player.LeaguePlayerId] = nextId;
+                    idToGuid[nextId] = player.LeaguePlayerId;
+                    nextId++;
                 }
             }
 
-            var request = new MMRCalculationRequest
+            validMatches.Add(match);
+            requests.Add(new MMRCalculationRequest
             {
-                Team1 = BuildTeam(teams[0], guidToIndex, leaguePlayerLookup, playersWithCurrentSeasonHistory),
-                Team2 = BuildTeam(teams[1], guidToIndex, leaguePlayerLookup, playersWithCurrentSeasonHistory),
-            };
+                Team1 = BuildTeam(teams[0], guidToId, leaguePlayerLookup, seenInBatch),
+                Team2 = BuildTeam(teams[1], guidToId, leaguePlayerLookup, seenInBatch),
+            });
 
-            var response = await mmrCalculationApiClient.CalculateMMRAsync(request);
+            foreach (var team in teams)
+            {
+                foreach (var player in team.Players)
+                {
+                    seenInBatch.Add(player.LeaguePlayerId);
+                }
+            }
+        }
+
+        if (requests.Count == 0)
+        {
+            return;
+        }
+
+        var responses = await mmrCalculationApiClient.CalculateMMRBatchAsync(requests);
+        if (responses.Count != requests.Count)
+        {
+            logger.LogCritical(
+                "MMR batch returned {ResponseCount} responses for {RequestCount} requests; aborting recalc",
+                responses.Count, requests.Count);
+            // Subsequent batches in the recalc loop reuse leaguePlayerLookup and
+            // playersWithCurrentSeasonHistory; if we skip applying this batch
+            // silently the next batch starts from stale state and the recalc
+            // ends up half-applied. Throwing aborts the whole operation before
+            // any SaveChangesAsync runs.
+            throw new InvalidOperationException(
+                $"MMR batch returned {responses.Count} responses for {requests.Count} requests");
+        }
+
+        for (var i = 0; i < responses.Count; i++)
+        {
+            var match = validMatches[i];
+            var response = responses[i];
 
             var playerResults = response.Team1.Players
                 .Concat(response.Team2.Players)
-                .ToDictionary(r => indexToGuid[r.Id]);
+                .ToDictionary(r => idToGuid[r.Id]);
 
             foreach (var (leaguePlayerId, result) in playerResults)
             {

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -613,7 +613,7 @@ public class V3MatchesService(
         const int batchSize = 200;
         for (var i = 0; i < matchesToReplay.Count; i += batchSize)
         {
-            var batch = matchesToReplay.Skip(i).Take(batchSize).ToList();
+            var batch = matchesToReplay.GetRange(i, Math.Min(batchSize, matchesToReplay.Count - i));
             await CalculateAndApplyMmrBatch(orgId, batch, leaguePlayerLookup, playersWithCurrentSeasonHistory);
         }
 
@@ -650,8 +650,7 @@ public class V3MatchesService(
         // front, virtually track in-batch first appearances here.
         var seenInBatch = new HashSet<Guid>(playersWithCurrentSeasonHistory);
 
-        var validMatches = new List<V3Match>(matches.Count);
-        var requests = new List<MMRCalculationRequest>(matches.Count);
+        var batchItems = new List<(V3Match Match, MMRCalculationRequest Request)>(matches.Count);
 
         foreach (var match in matches)
         {
@@ -673,12 +672,11 @@ public class V3MatchesService(
                 }
             }
 
-            validMatches.Add(match);
-            requests.Add(new MMRCalculationRequest
+            batchItems.Add((match, new MMRCalculationRequest
             {
                 Team1 = BuildTeam(teams[0], guidToId, leaguePlayerLookup, seenInBatch),
                 Team2 = BuildTeam(teams[1], guidToId, leaguePlayerLookup, seenInBatch),
-            });
+            }));
 
             foreach (var team in teams)
             {
@@ -689,37 +687,35 @@ public class V3MatchesService(
             }
         }
 
-        if (requests.Count == 0)
+        if (batchItems.Count == 0)
         {
             return;
         }
 
+        var requests = batchItems.Select(b => b.Request).ToList();
         var responses = await mmrCalculationApiClient.CalculateMMRBatchAsync(requests);
-        if (responses.Count != requests.Count)
+        if (responses.Count != batchItems.Count)
         {
             logger.LogError(
                 "MMR batch returned {ResponseCount} responses for {RequestCount} requests; aborting recalc",
-                responses.Count, requests.Count);
+                responses.Count, batchItems.Count);
             // Subsequent batches in the recalc loop reuse leaguePlayerLookup and
             // playersWithCurrentSeasonHistory; if we skip applying this batch
             // silently the next batch starts from stale state and the recalc
             // ends up half-applied. Throwing aborts the whole operation before
             // any SaveChangesAsync runs.
             throw new InvalidOperationException(
-                $"MMR batch returned {responses.Count} responses for {requests.Count} requests");
+                $"MMR batch returned {responses.Count} responses for {batchItems.Count} requests");
         }
 
         for (var i = 0; i < responses.Count; i++)
         {
-            var match = validMatches[i];
+            var match = batchItems[i].Match;
             var response = responses[i];
 
-            var playerResults = response.Team1.Players
-                .Concat(response.Team2.Players)
-                .ToDictionary(r => idToGuid[r.Id]);
-
-            foreach (var (leaguePlayerId, result) in playerResults)
+            foreach (var result in response.Team1.Players.Concat(response.Team2.Players))
             {
+                var leaguePlayerId = idToGuid[result.Id];
                 var lp = leaguePlayerLookup[leaguePlayerId];
                 var isFirstMatchOfSeason = !playersWithCurrentSeasonHistory.Contains(leaguePlayerId);
                 var delta = isFirstMatchOfSeason ? 0 : result.MMR - lp.Mmr;

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -697,7 +697,7 @@ public class V3MatchesService(
         var responses = await mmrCalculationApiClient.CalculateMMRBatchAsync(requests);
         if (responses.Count != requests.Count)
         {
-            logger.LogCritical(
+            logger.LogError(
                 "MMR batch returned {ResponseCount} responses for {RequestCount} requests; aborting recalc",
                 responses.Count, requests.Count);
             // Subsequent batches in the recalc loop reuse leaguePlayerLookup and


### PR DESCRIPTION
## Summary

- v3 season recalc had regressed from the v1 batch endpoint to one HTTP call per match — full-season recalcs paid 200× the round-trips. Restores batch usage with stable IDs across the chunk.
- Recalc now aborts (500) when the MMR API returns a different number of responses than requests, instead of silently returning a half-applied recalc.
- Stub fixture mirrors the real batch endpoint's carry-forward semantic so integration tests reflect production behavior.

## What's in here

**\`V3MatchesService.CalculateAndApplyMmrBatch\`**
- Builds all \`MMRCalculationRequest\`s up front with one stable \`long\` ID per LeaguePlayer for the chunk's lifetime, then sends them in a single \`CalculateMMRBatchAsync\` call. The mmr-api batch endpoint preserves carry-forward via its internal player map keyed on \`player.Id\`, so per-match results still reflect the previous match's updated ratings.
- A virtual \`seenInBatch\` tracker drives \`IsPreviousSeasonRating\` per match while building requests, so a player's second appearance in the batch sends \`false\` even though the real \`playersWithCurrentSeasonHistory\` set isn't mutated until response application.
- Throws \`InvalidOperationException\` on response/request count mismatch — surfaces as 500 to the caller instead of leaving \`leaguePlayerLookup\` and \`playersWithCurrentSeasonHistory\` at stale state for subsequent batches.

**\`StubMMRCalculationApiClient\`**
- \`CalculateMMRBatchAsync\` now uses a per-batch carry dictionary keyed on player \`Id\`. First appearance uses request \`mu\`/\`sigma\`; subsequent appearances inherit the previous match's response. Without this, the season-transition test saw delta=0 on the second new-season match because the stub returned identical output for identical input.
- Adds \`SingleCallCount\`, \`BatchCallCount\`, \`BatchSizes\`, \`ResetCallCounters()\`, and \`BatchResponseCountOverride\` for test instrumentation.

**Tests**
- \`RecalculateMatches_UsesBatchEndpoint\` submits 5 matches, runs recalc, and asserts the batch endpoint was hit exactly once with all 5 requests in a single call. Catches the regression where v3 recalc made one HTTP call per match.
- \`RecalculateMatches_AbortsWhenBatchResponseCountMismatches\` drives the stub to return zero responses and verifies recalc returns 500.

## Test plan

- [x] \`dotnet test --filter "FullyQualifiedName~RecalculateMatches"\` — all 6 recalc tests pass locally
- [x] \`dotnet test --filter "FullyQualifiedName~MatchTests"\` — all 24 match tests pass locally
- [ ] Trigger a full-season recalc on a populated season and confirm a single batch HTTP call to mmr-api per chunk (rather than one per match).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored batch MMR endpoint usage for season recalculations, replacing multiple per-match HTTP requests with a single batch call for improved performance.
  * Added validation to abort recalculation if batch response count doesn't match request count, preventing partially applied calculations.

* **Tests**
  * Added integration tests to verify batch recalculation endpoint usage and error handling for mismatched response counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->