### PR TITLE
chore: disable CodeRabbit auto review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` with `reviews.auto_review.enabled: false` so CodeRabbit no longer reviews every PR automatically
- Reviews can still be triggered manually via standard CodeRabbit commands (e.g. `@coderabbitai review`)

Reference: https://docs.coderabbit.ai/configuration/auto-review

## Test plan
- [ ] Confirm CodeRabbit does not post an automatic review on this PR after the config lands
- [ ] Verify a manual `@coderabbitai review` comment still works on a follow-up PR