### PR TITLE
chore(deps): bump svelte-clerk to 1.1.5

### DIFF
--- a/.changeset/bump-svelte-clerk.md
+++ b/.changeset/bump-svelte-clerk.md
@@ -1,0 +1,8 @@
+---
+"frontend": patch
+---
+
+Bump svelte-clerk from 0.20.6 to 1.1.5 (Clerk Core 3 alignment). Pulls in
+@clerk/backend 3.x and @clerk/shared 4.x. The 1.0.0 breaking change
+(removal of `<Protect>`, `<SignedIn>`, `<SignedOut>` in favour of `<Show>`)
+does not affect this codebase — none of those components were in use.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,8 @@ ADMIN_SECRET=<admin_secret>
 
 Releases are managed through lightweight changeset files in `.changeset/`. Feature PRs include a changeset markdown file specifying component bump types, and merging to main triggers an automated release PR. Merging the release PR creates per-component GitHub Releases. Deployment to Azure Container Apps is manual via the `Deploy Release` workflow, selecting a component and version from an existing GitHub Release tag.
 
+**Do not manually bump component versions.** The release PR workflow (`scripts/release/apply-changesets.mjs`) owns the `version` field in `frontend/package.json`, `api/package.json`, `mmr-api/package.json`, the `<Version>` element in `MMRProject.Api.csproj`, and the per-component `CHANGELOG.md` files. Add a `.changeset/*.md` describing the change and let the release PR compute the bump. Manual edits to these fields will be overwritten on the next release PR. (Editing entries under `dependencies` / `devDependencies` is unrelated and remains a manual operation.)
+
 ## Important Notes
 
 - Migrations run automatically on API startup when `Migration:Enabled` is true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@carbon/charts-svelte": "^1.27.8",
         "bits-ui": "^1.8.0",
@@ -17,7 +17,7 @@
         "dotenv": "^16.6.1",
         "formsnap": "^2.0.1",
         "lucide-svelte": "^0.577.0",
-        "svelte-clerk": "^0.20.6",
+        "svelte-clerk": "^1.1.5",
         "sveltekit-superforms": "^2.30.1",
         "tailwind-merge": "^2.6.1",
         "tailwind-variants": "^0.3.1",
@@ -158,36 +158,34 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.33.3",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.3.tgz",
-      "integrity": "sha512-cgkFVEYFG2nZn4QDuYBhiAwPtMdo8Yj7DAtq/SBQ5C/ainh3uxNRDgUj4bFn52qJkWLiCkraYJIw1b8dEUbUBg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.3.0.tgz",
+      "integrity": "sha512-6KuOaIig4CQPSn23I7xExkGKKi2rE2PEH3mvhnA41fktv3LqtPSifRb0xjmJEAwSZwJ8QY6uzk/jDccNof2eUA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.5",
-        "@clerk/types": "^4.101.23",
+        "@clerk/shared": "^4.8.3",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.5",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
-      "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.3.tgz",
+      "integrity": "sha512-HZViZBCTfOR2OreSBDMXcIRPgYiiYCE+GCCPrpjq/ZPcA6OsGiRCIQgUoGgGdAoFgr6Hk0TT00hnVK7g0qRKqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "3.1.3",
+        "@tanstack/query-core": "5.90.16",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
-        "std-env": "^3.9.0",
-        "swr": "2.3.4"
+        "std-env": "^3.9.0"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
@@ -200,18 +198,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@clerk/types": {
-      "version": "4.101.23",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.23.tgz",
-      "integrity": "sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.47.5"
-      },
-      "engines": {
-        "node": ">=18.17.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1684,6 +1670,16 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
+      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -3132,12 +3128,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -6589,16 +6579,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7263,14 +7243,14 @@
       }
     },
     "node_modules/svelte-clerk": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/svelte-clerk/-/svelte-clerk-0.20.6.tgz",
-      "integrity": "sha512-ufz1sMnoWLroMdcJXzq0HGFG/2K/TUHcsXZAF4SMl7eIsGs6mo9wwofA45w4VHQlc7hmvj6m++06iRp1xKnxVg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/svelte-clerk/-/svelte-clerk-1.1.5.tgz",
+      "integrity": "sha512-ZsZws/dJpMabWKPLNmgZ/9LO93F3+AlgVOFPPLn6zaI5ByNhDhXd+V4seMpxqG+3tsUwaBJb0blWFLFxTM5VWQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.31.0",
-        "@clerk/shared": "^3.45.0",
-        "set-cookie-parser": "^2.7.2"
+        "@clerk/backend": "3.3.0",
+        "@clerk/shared": "4.8.3",
+        "set-cookie-parser": "^3.0.1"
       },
       "peerDependencies": {
         "@sveltejs/kit": "^2.20.0",
@@ -7281,12 +7261,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/svelte-clerk/node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/svelte-eslint-parser": {
       "version": "0.43.0",
@@ -7450,19 +7424,6 @@
       "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/swr": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
-      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tabbable": {
@@ -7909,15 +7870,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.6.1",
     "formsnap": "^2.0.1",
     "lucide-svelte": "^0.577.0",
-    "svelte-clerk": "^0.20.6",
+    "svelte-clerk": "^1.1.5",
     "sveltekit-superforms": "^2.30.1",
     "tailwind-merge": "^2.6.1",
     "tailwind-variants": "^0.3.1",


### PR DESCRIPTION
## Summary
- Bumps `svelte-clerk` from `^0.20.6` to `^1.1.5`, aligning the SvelteKit Clerk integration with [Clerk Core 3](https://clerk.com/changelog/2026-03-03-core-3) (`@clerk/backend` 3.x, `@clerk/shared` 4.x).
- The `1.0.0` breaking change removed `<Protect>`, `<SignedIn>`, and `<SignedOut>` in favour of a unified `<Show>` component. A repo-wide grep confirmed none of those were in use, so no code changes are required.
- Adds a `frontend: patch` changeset following the existing convention for dependency bumps.

Note: `1.1.6` is the actual latest, but my npm has a `before` date pin that excludes it. `1.1.5` differs from `1.1.6` only by patch bumps to Clerk transitives.

## Test plan
- [x] `npm install` — clean, no peer-dep warnings
- [x] `npm run check` — 0 errors (20 pre-existing warnings unrelated to Clerk)
- [x] `npm run e2e` — **36/36 passed**, exercises full Clerk auth path: `<SignIn />`, `withClerkHandler`, `handleFetch` token forwarding, .NET API JWT validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded svelte-clerk to v1.1.5, aligning with Clerk Core 3, including backend 3.x and shared 4.x dependencies.

* **Documentation**
  * Added release management guidelines for automated version control processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->