### PR TITLE
fix(frontend): align submit-page preview with match-card name priority

### DIFF
--- a/.changeset/submit-page-name-priority.md
+++ b/.changeset/submit-page-name-priority.md
@@ -1,0 +1,5 @@
+---
+'frontend': patch
+---
+
+Fix submit-page preview to render the same player name (short handle / username) as every other match card. The preview now populates both `displayName` and `username` and lets the match-card pick its own priority, so a player previously shown as `Foo Bar` in the preview now correctly matches the `foob` rendered after submit.

--- a/frontend/e2e/submit.spec.ts
+++ b/frontend/e2e/submit.spec.ts
@@ -1,6 +1,18 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const SUBMIT_URL = '/test-org/test-league/submit';
+
+async function pickPlayer(page: Page, displayName: string) {
+  // Each unfilled slot renders an <input placeholder="Filter...">; once a
+  // player is chosen the input is replaced by a name display, so .first()
+  // always points at the next slot to fill.
+  const input = page.locator('input[placeholder="Filter..."]').first();
+  await input.fill(displayName);
+  await page
+    .getByRole('button', { name: new RegExp(displayName) })
+    .first()
+    .click();
+}
 
 test.describe('Submit match', () => {
   test('step-by-step flow: pick players → who won → loser score → preview', async ({
@@ -36,5 +48,43 @@ test.describe('Submit match', () => {
     await expect(dialog.getByLabel('Display name')).toBeVisible();
     await expect(dialog.getByLabel('Username (optional)')).toBeVisible();
     await expect(dialog.getByLabel('Email (optional)')).toBeVisible();
+  });
+
+  test('full happy path: fill 4 players → we won → score → submit', async ({
+    page,
+  }) => {
+    await page.goto(SUBMIT_URL);
+
+    await pickPlayer(page, 'Alice Anderson');
+    await pickPlayer(page, 'Bob Brown');
+    await pickPlayer(page, 'Carol Carter');
+    await pickPlayer(page, 'Dave Davies');
+
+    await expect(page.getByRole('heading', { name: 'Who won?' })).toBeVisible();
+    await page.getByRole('button', { name: /We won/ }).click();
+
+    await expect(
+      page.getByRole('heading', { name: /What was their score\?/ })
+    ).toBeVisible();
+    await page.getByRole('button', { name: '5', exact: true }).click();
+
+    await expect(page.getByRole('heading', { name: 'Submit?' })).toBeVisible();
+    // MatchCard renders username (short handle) when present, not displayName —
+    // so seeded players Alice/Bob/Carol/Dave appear as alia/bobr/caca/dada.
+    const preview = page.locator('#submit-step');
+    await expect(preview.getByText('alia')).toBeVisible();
+    await expect(preview.getByText('dada')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Submit the match' }).click();
+
+    // Server-side action redirects to the league leaderboard on success. The
+    // URL keeps a `#submit-step` fragment from earlier in-page anchor scrolls,
+    // so we check the destination by content instead.
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Leaderboard' })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Recent Matches' })
+    ).toBeVisible();
   });
 });

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/+page.svelte
@@ -46,7 +46,6 @@
     team2_player2: null,
   });
 
-  // Hydrate primary player from localStorage on mount
   $effect(() => {
     if (!browser) return;
     const primaryId = window.localStorage.getItem(PRIMARY_PLAYER_KEY);
@@ -66,36 +65,40 @@
   let team1Score = $state(-1);
   let team2Score = $state(-1);
 
-  let dialogOpen = $state(false);
-  let dialogSlot = $state<SlotName>('team1_player1');
-  let dialogDisplayName = $state('');
-  let dialogUsername = $state('');
-  let dialogEmail = $state('');
-  let dialogError = $state('');
+  let dialog = $state({
+    open: false,
+    slot: 'team1_player1' as SlotName,
+    displayName: '',
+    username: '',
+    email: '',
+    error: '',
+  });
 
   let submitting = $state(false);
 
   function openNewPlayerDialog(slot: SlotName, suggested: string) {
-    dialogSlot = slot;
-    dialogDisplayName = suggested;
-    dialogUsername = '';
-    dialogEmail = '';
-    dialogError = '';
-    dialogOpen = true;
+    dialog = {
+      open: true,
+      slot,
+      displayName: suggested,
+      username: '',
+      email: '',
+      error: '',
+    };
   }
 
   function saveNewPlayer() {
-    if (dialogDisplayName.trim() === '') {
-      dialogError = 'Display name is required';
+    if (dialog.displayName.trim() === '') {
+      dialog.error = 'Display name is required';
       return;
     }
-    slots[dialogSlot] = {
+    slots[dialog.slot] = {
       kind: 'new',
-      displayName: dialogDisplayName.trim(),
-      username: dialogUsername.trim(),
-      email: dialogEmail.trim(),
+      displayName: dialog.displayName.trim(),
+      username: dialog.username.trim(),
+      email: dialog.email.trim(),
     };
-    dialogOpen = false;
+    dialog.open = false;
   }
 
   function slotToFormValue(value: SlotValue): string {
@@ -142,13 +145,24 @@
   }
 
   function previewMatch(): MatchResponse {
-    const playerName = (slot: SlotValue) => {
-      if (slot === null) return 'Unknown';
+    const playerNames = (
+      slot: SlotValue
+    ): { displayName?: string; username?: string } => {
+      if (slot === null) return { displayName: 'Unknown' };
       if (slot.kind === 'league')
-        return slot.player.displayName ?? slot.player.username ?? 'Unknown';
+        return {
+          displayName: slot.player.displayName,
+          username: slot.player.username,
+        };
       if (slot.kind === 'member')
-        return slot.member.displayName ?? slot.member.username ?? 'Unknown';
-      return slot.displayName;
+        return {
+          displayName: slot.member.displayName,
+          username: slot.member.username,
+        };
+      return {
+        displayName: slot.displayName,
+        username: slot.username || undefined,
+      };
     };
 
     return {
@@ -168,7 +182,7 @@
           players: [slots.team1_player1, slots.team1_player2].map((s, i) => ({
             id: `t1p${i}`,
             leaguePlayerId: '',
-            displayName: playerName(s),
+            ...playerNames(s),
             index: i,
           })),
         },
@@ -180,7 +194,7 @@
           players: [slots.team2_player1, slots.team2_player2].map((s, i) => ({
             id: `t2p${i}`,
             leaguePlayerId: '',
-            displayName: playerName(s),
+            ...playerNames(s),
             index: i,
           })),
         },
@@ -188,7 +202,6 @@
     };
   }
 
-  // Persist primary + latest on submit
   function onBeforeSubmit() {
     if (!browser) return;
     const enteredIds = SLOTS.map((s) => {
@@ -242,64 +255,37 @@
     <input type="hidden" name="team1_score" value={team1Score} />
     <input type="hidden" name="team2_score" value={team2Score} />
 
+    {#snippet field(slot: SlotName, label: string, autofocus = false)}
+      <TeamMemberField
+        {label}
+        {autofocus}
+        value={slots[slot]}
+        onChange={(v) => (slots[slot] = v)}
+        leaguePlayers={data.players}
+        orgMembers={data.members}
+        {latestPlayerIds}
+        excludeIds={exclusions}
+        onCreateUser={(suggested) => openNewPlayerDialog(slot, suggested)}
+      />
+    {/snippet}
+
     <div class="flex flex-col gap-2">
       <div class="flex gap-3">
         <div id="team1-step" class="flex flex-1 flex-col gap-4">
           <h3 class="mb-2 text-center text-2xl">Team 1</h3>
-          <TeamMemberField
-            label="You"
-            value={slots.team1_player1}
-            onChange={(v) => (slots.team1_player1 = v)}
-            leaguePlayers={data.players}
-            orgMembers={data.members}
-            {latestPlayerIds}
-            excludeIds={exclusions}
-            onCreateUser={(suggested) =>
-              openNewPlayerDialog('team1_player1', suggested)}
-            autofocus
-          />
+          {@render field('team1_player1', 'You', true)}
           {#if slots.team1_player1 !== null || slots.team1_player2 !== null}
-            <TeamMemberField
-              label="Your teammate"
-              value={slots.team1_player2}
-              onChange={(v) => (slots.team1_player2 = v)}
-              leaguePlayers={data.players}
-              orgMembers={data.members}
-              {latestPlayerIds}
-              excludeIds={exclusions}
-              onCreateUser={(suggested) =>
-                openNewPlayerDialog('team1_player2', suggested)}
-            />
+            {@render field('team1_player2', 'Your teammate')}
           {/if}
         </div>
         <div class="min-h-full w-px bg-border"></div>
         <div id="team2-step" class="flex flex-1 flex-col gap-4">
           <h3 class="mb-2 text-center text-2xl">Team 2</h3>
           {#if team1Filled || slots.team2_player1 !== null}
-            <TeamMemberField
-              label="Opponent 1"
-              value={slots.team2_player1}
-              onChange={(v) => (slots.team2_player1 = v)}
-              leaguePlayers={data.players}
-              orgMembers={data.members}
-              {latestPlayerIds}
-              excludeIds={exclusions}
-              onCreateUser={(suggested) =>
-                openNewPlayerDialog('team2_player1', suggested)}
-            />
+            {@render field('team2_player1', 'Opponent 1')}
           {/if}
           {#if slots.team2_player1 !== null || slots.team2_player2 !== null}
-            <TeamMemberField
-              label="Opponent 2"
-              value={slots.team2_player2}
-              onChange={(v) => (slots.team2_player2 = v)}
-              leaguePlayers={data.players}
-              orgMembers={data.members}
-              {latestPlayerIds}
-              excludeIds={exclusions}
-              onCreateUser={(suggested) =>
-                openNewPlayerDialog('team2_player2', suggested)}
-            />
+            {@render field('team2_player2', 'Opponent 2')}
           {/if}
         </div>
       </div>
@@ -370,7 +356,7 @@
   </form>
 </div>
 
-<Dialog.Root bind:open={dialogOpen}>
+<Dialog.Root bind:open={dialog.open}>
   <Dialog.Content>
     <Dialog.Header>
       <Dialog.Title>Add new player</Dialog.Title>
@@ -381,15 +367,15 @@
     </Dialog.Header>
 
     <div class="mt-4 flex flex-col gap-4">
-      {#if dialogError}
-        <Alert variant="destructive">{dialogError}</Alert>
+      {#if dialog.error}
+        <Alert variant="destructive">{dialog.error}</Alert>
       {/if}
 
       <div class="space-y-2">
         <Label for="new-player-display-name">Display name</Label>
         <Input
           id="new-player-display-name"
-          bind:value={dialogDisplayName}
+          bind:value={dialog.displayName}
           placeholder="New teammate"
         />
       </div>
@@ -397,7 +383,7 @@
         <Label for="new-player-username">Username (optional)</Label>
         <Input
           id="new-player-username"
-          bind:value={dialogUsername}
+          bind:value={dialog.username}
           placeholder="short-handle"
         />
       </div>
@@ -405,7 +391,7 @@
         <Label for="new-player-email">Email (optional)</Label>
         <Input
           id="new-player-email"
-          bind:value={dialogEmail}
+          bind:value={dialog.email}
           type="email"
           placeholder="new.player@example.com"
         />
@@ -416,7 +402,7 @@
       <Button
         type="button"
         variant="outline"
-        onclick={() => (dialogOpen = false)}
+        onclick={() => (dialog.open = false)}
       >
         Cancel
       </Button>


### PR DESCRIPTION
## Summary

- The submit-page preview rendered each player using `displayName ?? username`, but `match-card` (used everywhere else — leaderboard, player page, admin matches) renders `username ?? displayName`. A player with `displayName: "Foo Bar"` / `username: "foob"` previewed as **Foo Bar** but appeared as **foob** in the post-submit match list. Now populates both fields on preview players and lets match-card decide.
- Drive-by `/simplify`: four near-identical `<TeamMemberField>` calls collapsed into a Svelte snippet, six dialog `$state` vars consolidated into one object, two narration comments removed. Net –14 lines on `+page.svelte`.
- New full happy-path e2e test (`submit.spec.ts`) — fills four players, picks a winner and score, asserts the preview renders usernames, submits, and verifies the leaderboard loads. Catches regressions across the snippet wiring, dialog-state object, preview population, and form-action redirect.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run e2e -- submit.spec.ts` — all 4 tests pass (~40s)
- [ ] Reviewer to spot-check that real submits in the league still render the right names on the leaderboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed player identity rendering on the submit-page preview to ensure player names display consistently with match cards.

* **Tests**
  * Added comprehensive end-to-end test validating the complete match submission workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/office-rivals/mmr-project/pull/239)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->