### PR TITLE
fix(mmr-api): switch base image to distroless static-debian12:nonroot

### DIFF
--- a/.changeset/mmr-api-distroless-base.md
+++ b/.changeset/mmr-api-distroless-base.md
@@ -1,0 +1,5 @@
+---
+'mmr-api': patch
+---
+
+Switch the `mmr-api` Docker base image from `debian:bookworm` to `gcr.io/distroless/static-debian12:nonroot`. The previous Debian base shipped without `ca-certificates`, so every outbound HTTPS call from the Go binary failed TLS verification — which silently broke OTLP log/metric/trace export to Grafana Cloud (since the SDK's error reporting is itself routed through the broken slog→OTel pipeline). Distroless static includes a CA bundle, runs as non-root, and shrinks the image to ~42 MB. The build now uses `CGO_ENABLED=0` since `mmr-api`'s dependencies are all pure Go.

--- a/mmr-api/Dockerfile
+++ b/mmr-api/Dockerfile
@@ -1,16 +1,14 @@
 ARG GO_VERSION=1
 FROM golang:${GO_VERSION}-bookworm AS builder
 
-VOLUME /data
-
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 COPY . .
-RUN go build -v -o /run-app .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /run-app .
 
 
-FROM debian:bookworm
+FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY --from=builder /run-app /usr/local/bin/
-CMD ["run-app"]
+COPY --from=builder /run-app /run-app
+ENTRYPOINT ["/run-app"]


### PR DESCRIPTION
## Summary

The previous `debian:bookworm` base shipped without `ca-certificates`, so every outbound HTTPS call (specifically OTLP log/metric/trace export to Grafana Cloud) failed TLS verification. The failure was silent because once `slog.SetDefault(otelslog.NewLogger(...))` is wired in `telemetry.Init`, the OTel SDK's own error reporting routes through the now-broken pipeline — so we had a healthy-looking Container App serving 200s while emitting **zero** logs to Loki.

`gcr.io/distroless/static-debian12:nonroot`:
- ✅ Ships with a CA cert bundle (3563 lines)
- ✅ Runs as non-root by default (uid 65532)
- ✅ ~42 MB final image (vs. the previous Debian-based ~150 MB+)
- ✅ No shell / package manager → minimal attack surface
- Build switches to `CGO_ENABLED=0` + `-trimpath` + `-s -w`. `mmr-api`'s deps are all pure Go (`gin`, `go.opentelemetry.io/*`, `joho/godotenv`, `swaggo`) so static linking is safe and required by distroless static.

## Verification

Local before/after with identical OTel env vars (endpoint, headers from `otel-headers` secret, `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=local-bjarkehs-distroless`):

| Image | Probe → Loki entries within 30s |
|---|---|
| Current prod image (`25611398557.8`, debian-based) | **0 lines** |
| New distroless build | **2 lines** (one per 401 probe), labeled `service_name=mmr-api`, attribute `http.request.method=POST`, status 401 ✅ |

Both runs hit the container with the same `curl -X POST /api/v1/mmr-calculation` and same env. Only the base image changed.

## Trade-offs

- ❌ No shell — `az containerapp exec` into the running pod no longer works for ad-hoc debugging. If that becomes painful, switch to `:debug-nonroot` via a separate `Dockerfile.debug` rather than reverting the prod image.
- ❌ Distroless `static` requires `CGO_ENABLED=0`. If anyone later adds a CGO-using dep, the build will fail loudly — at which point switch to `gcr.io/distroless/base-debian12:nonroot`.

## Test plan

- [x] `docker build` succeeds, image is 42 MB, CA bundle present (3563-line `/etc/ssl/certs/ca-certificates.crt`)
- [x] Container starts and serves a 401 on `/api/v1/mmr-calculation` (auth middleware running)
- [x] Loki receives `http.request` entries from the new image with the exact same OTel env that produced 0 entries from the old image
- [ ] Reviewer to confirm the `Deploy Release` workflow re-builds via `azure/container-apps-deploy-action@v2` (it should — it builds from `appSourcePath`, which respects this Dockerfile)
- [ ] Post-deploy: `{service_name="mmr-api", deployment_environment="production"}` should show `http.request` entries in Grafana Cloud Loki for the first time

## Follow-ups (separate)

`mmr-api/main.go:32` uses a 5s OTel shutdown timeout. With `minReplicas: 0` on this Container App and a fresh TLS handshake on every cold start, that's tight. Worth bumping to 30s in a follow-up so cold-start logs flush reliably before SIGTERM. Not urgent now that exports work — the periodic 1s flush will catch the bulk during the request lifetime.