### PR TITLE
feat(frontend): redesign /random with bespoke touch UI

### DIFF
--- a/.changeset/random-touch-redesign.md
+++ b/.changeset/random-touch-redesign.md
@@ -1,5 +1,5 @@
 ---
-'frontend': minor
+"frontend": minor
 ---
 
 Redesign the `/random` page with a bespoke touch UI. On touch devices the page

--- a/.changeset/random-touch-redesign.md
+++ b/.changeset/random-touch-redesign.md
@@ -1,0 +1,10 @@
+---
+'frontend': minor
+---
+
+Redesign the `/random` page with a bespoke touch UI. On touch devices the page
+now opens a full-bleed surface where users drop fingers and two random fingers
+become the white team while two become the brown team (extras are ignored,
+minimum four). Desktop visitors keep the original names form. A pill toggle in
+the header lets touch users switch back to the names form without leaving the
+page.

--- a/frontend/src/routes/(authed)/random/+page.svelte
+++ b/frontend/src/routes/(authed)/random/+page.svelte
@@ -5,6 +5,7 @@
   import Input from '$lib/components/ui/input/input.svelte';
   import Label from '$lib/components/ui/label/label.svelte';
   import { getRandomTeamsSessionStorageKey } from '$lib/util/session';
+  import { Hand, Keyboard, RotateCcw } from 'lucide-svelte';
   import type { PageData } from './$types';
 
   interface Props {
@@ -13,13 +14,48 @@
 
   let { data }: Props = $props();
 
-  const REQUIRED_TOUCHES = 4;
+  const MIN_TOUCHES = 4;
   const COUNTDOWN_SECONDS = 3;
-  const RESULT_DISPLAY_MS = 5000;
   const TEAM_SIZE = 2;
 
   type Tab = 'names' | 'touch';
+
+  // SSR can't know if the device is touch-capable. Render the names form by
+  // default and flip on hydration. `isTouchDevice` stays `null` until we know,
+  // so we can avoid showing either UI in a wrong state during the first paint.
+  let isTouchDevice = $state<boolean | null>(null);
   let activeTab = $state<Tab>('names');
+  let userSwitchedTab = $state(false);
+
+  $effect(() => {
+    if (!browser) return;
+    const mq = window.matchMedia('(hover: none) and (pointer: coarse)');
+    const apply = () => {
+      const touch = mq.matches || navigator.maxTouchPoints > 0;
+      isTouchDevice = touch;
+      if (touch && activeTab === 'names' && !userSwitchedTab) {
+        activeTab = 'touch';
+      }
+      if (!touch) {
+        activeTab = 'names';
+      }
+    };
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  });
+
+  function selectTab(tab: Tab) {
+    activeTab = tab;
+    userSwitchedTab = true;
+    // Switching away from the touch surface mid-countdown should clear it,
+    // otherwise the previous gesture's state would leak when the user comes
+    // back. (Also: any fingers still on the screen will fire touchend later
+    // and we want them to no-op.)
+    if (tab === 'names') {
+      resetTouchRandomizer();
+    }
+  }
 
   function fisherYatesShuffle<T>(array: T[]): T[] {
     const shuffled = [...array];
@@ -60,35 +96,28 @@
   let touches = $state<TouchMarker[]>([]);
   let countdown = $state<number | null>(null);
   let countdownTimer: ReturnType<typeof setInterval> | null = null;
-  let resetTimer: ReturnType<typeof setTimeout> | null = null;
   let showingResult = $state(false);
-  let isMobile = $state(false);
-
-  $effect(() => {
-    if (browser) {
-      isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-    }
-  });
 
   $effect(() => {
     return () => {
       if (countdownTimer !== null) {
         clearInterval(countdownTimer);
       }
-      if (resetTimer !== null) {
-        clearTimeout(resetTimer);
-      }
     };
   });
 
   function handleTouchStart(event: TouchEvent) {
-    event.preventDefault();
-
+    // Bail out *before* preventDefault — once colors are assigned, taps on
+    // the "Go again" button (which lives inside the touch surface) need to
+    // synthesize a click, and iOS suppresses synthesized clicks if any
+    // touchstart handler in the bubble path called preventDefault.
     if (showingResult) {
       return;
     }
 
-    const rect = (event.target as HTMLElement).getBoundingClientRect();
+    event.preventDefault();
+
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
 
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i];
@@ -103,14 +132,24 @@
       });
     }
 
-    if (touches.length >= REQUIRED_TOUCHES) {
+    // Any finger added/removed during placement restarts the countdown so the
+    // user has a beat to settle before colors get assigned.
+    if (touches.length >= MIN_TOUCHES) {
       resetCountdown();
     }
   }
 
   function handleTouchMove(event: TouchEvent) {
+    // Markers freeze once colors are assigned. Skip preventDefault so the
+    // browser keeps synthesizing the click for "Go again" — `touch-action:
+    // none` on the surface still blocks scroll/zoom for stuck-down fingers.
+    if (showingResult) {
+      return;
+    }
+
     event.preventDefault();
-    const rect = (event.target as HTMLElement).getBoundingClientRect();
+
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
 
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i];
@@ -126,11 +165,11 @@
   }
 
   function handleTouchEnd(event: TouchEvent) {
-    event.preventDefault();
-
     if (showingResult) {
       return;
     }
+
+    event.preventDefault();
 
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i];
@@ -141,22 +180,22 @@
       }
     }
 
-    if (touches.length < REQUIRED_TOUCHES) {
+    if (touches.length < MIN_TOUCHES) {
       if (countdownTimer !== null) {
         clearInterval(countdownTimer);
         countdownTimer = null;
       }
       countdown = null;
+    } else {
+      // Still above threshold — restart so the user gets a fresh beat after
+      // changing the lineup.
+      resetCountdown();
     }
   }
 
   function resetCountdown() {
     if (countdownTimer !== null) {
       clearInterval(countdownTimer);
-    }
-    if (resetTimer !== null) {
-      clearTimeout(resetTimer);
-      resetTimer = null;
     }
 
     showingResult = false;
@@ -177,7 +216,7 @@
   function assignColors() {
     const touchCount = touches.length;
 
-    if (touchCount < REQUIRED_TOUCHES) {
+    if (touchCount < MIN_TOUCHES) {
       countdown = null;
       showingResult = false;
       return;
@@ -186,28 +225,20 @@
     const indices = touches.map((_, i) => i);
     const shuffled = fisherYatesShuffle(indices);
 
-    const whiteCount = Math.min(TEAM_SIZE, touchCount);
-    const brownCount = Math.min(TEAM_SIZE, Math.max(0, touchCount - TEAM_SIZE));
-
-    for (let i = 0; i < whiteCount; i++) {
+    for (let i = 0; i < TEAM_SIZE; i++) {
       touches[shuffled[i]].color = 'white';
     }
-
-    for (let i = 0; i < brownCount; i++) {
-      touches[shuffled[whiteCount + i]].color = 'brown';
+    for (let i = 0; i < TEAM_SIZE; i++) {
+      touches[shuffled[TEAM_SIZE + i]].color = 'brown';
     }
 
-    touches = touches.filter((t) => t.color !== null);
+    // Intentionally do NOT filter out the uncolored extras. They are still
+    // active touches in the browser; we need to keep their identifiers in
+    // `touches` so the (suppressed) touchend events still match an entry.
+    // The render branch hides null-color markers during the result phase.
 
     countdown = null;
     showingResult = true;
-
-    if (resetTimer !== null) {
-      clearTimeout(resetTimer);
-    }
-    resetTimer = setTimeout(() => {
-      resetTouchRandomizer();
-    }, RESULT_DISPLAY_MS);
   }
 
   function resetTouchRandomizer() {
@@ -218,127 +249,268 @@
       clearInterval(countdownTimer);
       countdownTimer = null;
     }
-    if (resetTimer !== null) {
-      clearTimeout(resetTimer);
-      resetTimer = null;
-    }
   }
+
+  const headerSubtitle = $derived.by(() => {
+    if (activeTab === 'names') {
+      return teams.length === 2
+        ? 'Tap generate again to reshuffle.'
+        : 'Type four names and tap generate.';
+    }
+    if (showingResult) {
+      return 'Teams ready — tap "Go again" to reset';
+    }
+    if (countdown !== null && countdown > 0) {
+      return 'Hold still…';
+    }
+    if (touches.length === 0) {
+      return `Place at least ${MIN_TOUCHES} fingers on the screen`;
+    }
+    if (touches.length < MIN_TOUCHES) {
+      return `${touches.length} of ${MIN_TOUCHES} fingers — keep going`;
+    }
+    return `${touches.length} fingers down`;
+  });
+
+  const allPlayersFilled = $derived(
+    !players.some((p) => p == null || p.trim() === '')
+  );
 </script>
 
-<div class="flex flex-col gap-8">
-  <PageTitle>Random Team Generator</PageTitle>
-
-  <div class="flex gap-2 border-b" role="tablist" aria-label="Randomizer mode">
-    <button
-      role="tab"
-      aria-selected={activeTab === 'names'}
-      class="px-4 py-2 transition-colors {activeTab === 'names'
-        ? 'border-b-2 border-primary font-semibold'
-        : 'text-muted-foreground hover:text-foreground'}"
-      onclick={() => (activeTab = 'names')}
-    >
-      Names
-    </button>
+{#snippet pillTabs()}
+  <div
+    class="flex items-center gap-1 rounded-full border bg-muted p-1 text-xs"
+    role="tablist"
+    aria-label="Randomizer mode"
+  >
     <button
       role="tab"
       aria-selected={activeTab === 'touch'}
-      class="px-4 py-2 transition-colors {activeTab === 'touch'
-        ? 'border-b-2 border-primary font-semibold'
-        : 'text-muted-foreground hover:text-foreground'}"
-      onclick={() => (activeTab = 'touch')}
+      class="flex items-center gap-1 rounded-full px-3 py-1 transition-colors {activeTab ===
+      'touch'
+        ? 'bg-background font-semibold shadow-sm'
+        : 'text-muted-foreground'}"
+      onclick={() => selectTab('touch')}
     >
+      <Hand class="h-3.5 w-3.5" />
       Touch
     </button>
-  </div>
-
-  {#if activeTab === 'names'}
-    <div class="grid grid-cols-2 gap-4">
-      {#each players as player, idx}
-        <div class="flex flex-col gap-2">
-          <Label for="player-{idx}">Player {idx + 1}</Label>
-          <Input id="player-{idx}" bind:value={players[idx]} />
-        </div>
-      {/each}
-    </div>
-    <Button
-      type="button"
-      disabled={players.some((p) => p == null || p.trim() === '')}
-      onclick={generateTeams}>Generate Teams</Button
+    <button
+      role="tab"
+      aria-selected={activeTab === 'names'}
+      class="flex items-center gap-1 rounded-full px-3 py-1 transition-colors {activeTab ===
+      'names'
+        ? 'bg-background font-semibold shadow-sm'
+        : 'text-muted-foreground'}"
+      onclick={() => selectTab('names')}
     >
-    {#if teams.length === 2}
-      <div class="flex flex-row gap-4 text-center">
-        <div class="flex flex-1 flex-col">
-          <h3 class="text-2xl">Team 1</h3>
-          <ul>
-            {#each teams[0] as player}
-              <li>{player}</li>
-            {/each}
-          </ul>
-        </div>
-        <div class="min-h-full w-px self-stretch bg-border"></div>
-        <div class="flex flex-1 flex-col">
-          <h3 class="text-2xl">Team 2</h3>
-          <ul>
-            {#each teams[1] as player}
-              <li>{player}</li>
-            {/each}
-          </ul>
-        </div>
-      </div>
-    {/if}
-  {:else if !isMobile}
-    <div class="rounded-lg bg-muted p-4 text-center">
-      <p class="text-muted-foreground">
-        This feature only works on mobile devices with touch support.
-      </p>
-    </div>
-  {:else}
-    <div class="flex flex-col gap-4">
-      <p class="text-center text-sm text-muted-foreground">
-        Place {REQUIRED_TOUCHES} fingers on the screen. After a {COUNTDOWN_SECONDS}
-        second countdown, {TEAM_SIZE} fingers will be white team and {TEAM_SIZE} will
-        be brown team.
-      </p>
+      <Keyboard class="h-3.5 w-3.5" />
+      Names
+    </button>
+  </div>
+{/snippet}
 
+{#snippet namesForm()}
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    {#each players as player, idx}
+      <div class="flex flex-col gap-2">
+        <Label for="player-{idx}">Player {idx + 1}</Label>
+        <Input id="player-{idx}" bind:value={players[idx]} />
+      </div>
+    {/each}
+  </div>
+  <Button type="button" disabled={!allPlayersFilled} onclick={generateTeams}
+    >Generate Teams</Button
+  >
+  {#if teams.length === 2}
+    <div class="flex flex-row gap-4 text-center">
+      <div class="flex flex-1 flex-col">
+        <h3 class="text-2xl">Team 1</h3>
+        <ul>
+          {#each teams[0] as player}
+            <li>{player}</li>
+          {/each}
+        </ul>
+      </div>
+      <div class="min-h-full w-px self-stretch bg-border"></div>
+      <div class="flex flex-1 flex-col">
+        <h3 class="text-2xl">Team 2</h3>
+        <ul>
+          {#each teams[1] as player}
+            <li>{player}</li>
+          {/each}
+        </ul>
+      </div>
+    </div>
+  {/if}
+{/snippet}
+
+<!--
+  Touch devices: full-bleed overlay with a sticky header that holds the title,
+  status copy, and the Touch/Names pill toggle. The body below the header swaps
+  between the touch surface and the names form so the chrome never jumps.
+
+  Desktop: render the original names form below the page title.
+-->
+
+{#if isTouchDevice === true}
+  <div
+    class="fixed inset-x-0 top-0 z-30 flex flex-col bg-background"
+    style="bottom: calc(env(safe-area-inset-bottom) + 64px);"
+  >
+    <header
+      class="flex shrink-0 items-center justify-between gap-2 border-b bg-card px-4 py-3"
+    >
+      <div class="flex min-w-0 flex-col">
+        <h1 class="text-lg font-bold leading-tight">Random Teams</h1>
+        <p class="truncate text-xs text-muted-foreground">{headerSubtitle}</p>
+      </div>
+      {@render pillTabs()}
+    </header>
+
+    {#if activeTab === 'touch'}
       <div
-        class="relative min-h-screen w-full touch-none select-none bg-muted"
+        role="application"
+        aria-label="Touch randomizer surface"
+        class="relative flex-1 touch-none select-none overflow-hidden bg-muted"
         ontouchstart={handleTouchStart}
         ontouchmove={handleTouchMove}
         ontouchend={handleTouchEnd}
         ontouchcancel={handleTouchEnd}
       >
+        {#if touches.length === 0 && !showingResult}
+          <div
+            class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center"
+          >
+            <div
+              class="flex h-20 w-20 items-center justify-center rounded-full border-2 border-dashed border-primary/40 bg-background/60"
+            >
+              <Hand class="h-10 w-10 text-primary" />
+            </div>
+            <p class="text-2xl font-bold">Place your fingers</p>
+            <p class="max-w-xs text-sm text-muted-foreground">
+              At least {MIN_TOUCHES}. After a {COUNTDOWN_SECONDS}-second
+              countdown, two random fingers become
+              <span class="font-semibold text-foreground">white team</span>
+              and two become
+              <span class="font-semibold text-foreground">brown team</span>.
+            </p>
+          </div>
+        {/if}
+
         {#if countdown !== null && countdown > 0}
           <div
             class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center"
           >
-            <div class="animate-pulse text-9xl font-bold text-primary">
+            <div
+              class="animate-pulse text-[12rem] font-bold leading-none text-primary/80"
+            >
               {countdown}
             </div>
           </div>
         {/if}
 
-        {#each touches as touch (touch.identifier)}
+        {#if showingResult}
           <div
-            class="absolute flex h-24 w-24 items-center justify-center rounded-full border-4 shadow-lg transition-colors duration-500"
-            class:pulse-scale={countdown !== null}
-            class:border-white={touch.color === 'white'}
-            class:border-amber-900={touch.color === 'brown'}
-            class:border-gray-300={touch.color === null}
-            style="left: {touch.x}px; top: {touch.y}px; transform: translate(-50%, -50%);"
+            class="pointer-events-none absolute inset-x-0 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center gap-2 px-6 text-center"
           >
-            <div
-              class="rounded-full transition-colors duration-500"
-              class:bg-white={touch.color === 'white'}
-              class:bg-amber-900={touch.color === 'brown'}
-              class:bg-gray-300={touch.color === null}
-              style="width: 72px; height: 72px;"
-            ></div>
+            <p class="text-sm uppercase tracking-widest text-muted-foreground">
+              Teams
+            </p>
+            <div class="flex items-center gap-3 text-2xl font-bold">
+              <span class="inline-flex items-center gap-2">
+                <span
+                  class="h-4 w-4 rounded-full border-2 border-foreground bg-white"
+                ></span>
+                White
+              </span>
+              <span class="text-muted-foreground">vs</span>
+              <span class="inline-flex items-center gap-2">
+                <span class="h-4 w-4 rounded-full bg-amber-900"></span>
+                Brown
+              </span>
+            </div>
           </div>
+        {/if}
+
+        {#if showingResult}
+          {@const whiteTouches = touches.filter((t) => t.color === 'white')}
+          {@const brownTouches = touches.filter((t) => t.color === 'brown')}
+          <svg
+            class="pointer-events-none absolute inset-0 z-[5] h-full w-full"
+            aria-hidden="true"
+          >
+            {#if whiteTouches.length === 2}
+              <line
+                x1={whiteTouches[0].x}
+                y1={whiteTouches[0].y}
+                x2={whiteTouches[1].x}
+                y2={whiteTouches[1].y}
+                stroke="#ffffff"
+                stroke-width="6"
+                stroke-linecap="round"
+                stroke-dasharray="14 10"
+              />
+            {/if}
+            {#if brownTouches.length === 2}
+              <line
+                x1={brownTouches[0].x}
+                y1={brownTouches[0].y}
+                x2={brownTouches[1].x}
+                y2={brownTouches[1].y}
+                stroke="#78350f"
+                stroke-width="6"
+                stroke-linecap="round"
+                stroke-dasharray="14 10"
+              />
+            {/if}
+          </svg>
+        {/if}
+
+        {#each touches as touch (touch.identifier)}
+          {#if !(showingResult && touch.color === null)}
+            <div
+              class="pointer-events-none absolute flex h-28 w-28 items-center justify-center rounded-full border-4 shadow-lg transition-colors duration-500"
+              class:pulse-scale={countdown !== null && countdown > 0}
+              class:border-white={touch.color === 'white'}
+              class:border-amber-900={touch.color === 'brown'}
+              class:border-primary={touch.color === null}
+              style="left: {touch.x}px; top: {touch.y}px; transform: translate(-50%, -50%);"
+            >
+              <div
+                class="rounded-full transition-colors duration-500"
+                class:bg-white={touch.color === 'white'}
+                class:bg-amber-900={touch.color === 'brown'}
+                class:bg-primary={touch.color === null}
+                class:opacity-30={touch.color === null}
+                style="width: 88px; height: 88px;"
+              ></div>
+            </div>
+          {/if}
         {/each}
+
+        {#if showingResult}
+          <button
+            class="absolute bottom-6 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-lg"
+            onclick={resetTouchRandomizer}
+          >
+            <RotateCcw class="h-4 w-4" />
+            Go again
+          </button>
+        {/if}
       </div>
-    </div>
-  {/if}
-</div>
+    {:else}
+      <div class="flex flex-1 flex-col gap-6 overflow-y-auto bg-background p-4">
+        {@render namesForm()}
+      </div>
+    {/if}
+  </div>
+{:else}
+  <div class="flex flex-col gap-8">
+    <PageTitle>Random Team Generator</PageTitle>
+    {@render namesForm()}
+  </div>
+{/if}
 
 <style>
   @keyframes pulse-scale {

--- a/frontend/src/routes/(authed)/random/+page.svelte
+++ b/frontend/src/routes/(authed)/random/+page.svelte
@@ -363,7 +363,11 @@
     >
       <div class="flex min-w-0 flex-col">
         <h1 class="text-lg font-bold leading-tight">Random Teams</h1>
-        <p class="truncate text-xs text-muted-foreground">{headerSubtitle}</p>
+        <p
+          class="line-clamp-2 min-h-[2lh] text-xs leading-snug text-muted-foreground"
+        >
+          {headerSubtitle}
+        </p>
       </div>
       {@render pillTabs()}
     </header>


### PR DESCRIPTION
## Summary

- **Touch devices** now open `/random` as a full-bleed overlay with a sticky header (title, live status, Touch/Names pill toggle). The body swaps between the touch surface and the names form so the chrome never jumps when switching modes. Desktop visitors keep the original names form below `PageTitle`.
- **Touch surface**: any finger added or removed during placement restarts the 3s countdown. After countdown, two random fingers become white team, two become brown, extras stay tracked but hidden. Bubbles freeze in place until "Go again" is tapped — no auto-reset, no movement, no new fingers accepted during the result phase.
- Touch handlers skip `preventDefault` once the result is showing so iOS still synthesizes the click for the "Go again" button.
- Header subtitle reserves two lines (`line-clamp-2 min-h-[2lh]`) so longer copy ("Place at least 4 fingers on the screen") doesn't truncate and the header height stays stable.

## Known limitation

iPhone Safari hard-caps multi-touch tracking at 5 (`navigator.maxTouchPoints === 5`). When a 6th finger lands, the platform fires `touchcancel` for all 5 active touches with `event.touches.length === 0` and stops tracking the originals — there's no web API to override this. iPad's cap is higher (typically 11 on iPad Pro). Not handled in this PR; possible follow-ups would either swallow the suspicious cancel mid-countdown to keep the result flow alive, or surface a "max 5 fingers on iPhone" hint.

## Test plan

- [ ] On a phone, open `/random` — touch overlay loads by default, bottom navbar still visible.
- [ ] Place 4 fingers → countdown starts; lift one → countdown cancels; place a 5th → countdown restarts.
- [ ] After countdown, two white + two brown bubbles + dashed lines appear and stay frozen even if you drag or lift fingers.
- [ ] "Go again" resets cleanly.
- [ ] Tap "Names" tab — header stays put, body swaps to the names form, can generate teams normally.
- [ ] Tap "Touch" tab — back to the touch surface (clean state).
- [ ] On a non-touch desktop browser, `/random` shows the original names form with `PageTitle`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned `/random` page with dedicated interface for touch devices
  * Implemented full-bleed drop-fingers interaction (assigns two fingers per team)
  * Added header toggle to switch between touch UI and names form without leaving the page
  * Desktop experience with names form remains unchanged

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/office-rivals/mmr-project/pull/244)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->