### PR TITLE
fix(frontend): disable spellcheck on match submit player inputs

### DIFF
--- a/.changeset/spellcheck-match-inputs.md
+++ b/.changeset/spellcheck-match-inputs.md
@@ -1,0 +1,5 @@
+---
+'frontend': patch
+---
+
+Disable spellcheck on player name inputs in the match submit flow so Safari doesn't flag initials and short handles as typos.

--- a/.changeset/spellcheck-match-inputs.md
+++ b/.changeset/spellcheck-match-inputs.md
@@ -1,5 +1,5 @@
 ---
-'frontend': patch
+"frontend": patch
 ---
 
 Disable spellcheck and autocorrect on player name inputs in the match submit flow so Safari doesn't flag initials and short handles as typos. Also disables iOS autocapitalization on the player filter and username inputs.

--- a/.changeset/spellcheck-match-inputs.md
+++ b/.changeset/spellcheck-match-inputs.md
@@ -2,4 +2,4 @@
 'frontend': patch
 ---
 
-Disable spellcheck on player name inputs in the match submit flow so Safari doesn't flag initials and short handles as typos.
+Disable spellcheck and autocorrect on player name inputs in the match submit flow so Safari doesn't flag initials and short handles as typos. Also disables iOS autocapitalization on the player filter and username inputs.

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/+page.svelte
@@ -391,6 +391,7 @@
           id="new-player-display-name"
           bind:value={dialogDisplayName}
           placeholder="New teammate"
+          spellcheck={false}
         />
       </div>
       <div class="space-y-2">
@@ -399,6 +400,7 @@
           id="new-player-username"
           bind:value={dialogUsername}
           placeholder="short-handle"
+          spellcheck={false}
         />
       </div>
       <div class="space-y-2">

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/+page.svelte
@@ -392,6 +392,7 @@
           bind:value={dialogDisplayName}
           placeholder="New teammate"
           spellcheck={false}
+          autocorrect="off"
         />
       </div>
       <div class="space-y-2">
@@ -401,6 +402,8 @@
           bind:value={dialogUsername}
           placeholder="short-handle"
           spellcheck={false}
+          autocorrect="off"
+          autocapitalize="none"
         />
       </div>
       <div class="space-y-2">

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/components/team-member-field.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/components/team-member-field.svelte
@@ -101,6 +101,8 @@
       placeholder="Filter..."
       autofocus={autofocus ? autofocus : undefined}
       spellcheck={false}
+      autocorrect="off"
+      autocapitalize="none"
     />
     {#if filter.length === 0 && latestPlayers.length > 0}
       <p class="text-sm">Recent players</p>

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/components/team-member-field.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/submit/components/team-member-field.svelte
@@ -100,6 +100,7 @@
       bind:value={filter}
       placeholder="Filter..."
       autofocus={autofocus ? autofocus : undefined}
+      spellcheck={false}
     />
     {#if filter.length === 0 && latestPlayers.length > 0}
       <p class="text-sm">Recent players</p>


### PR DESCRIPTION
## Summary
Disables Safari's spell-check / autocorrect / iOS autocapitalize on the player-name inputs in the match submit flow so initials and short handles are no longer flagged as typos.

After verifying the original suggestion in the issue, `spellcheck="false"` alone is **not enough for Safari** — per MDN it is only a hint, and Safari relies on Apple-specific `autocorrect="off"` to actually suppress the red underlines. iOS Safari additionally auto-capitalizes the first letter of search and username inputs.

Applied to three inputs:
- `submit/components/team-member-field.svelte` — player filter (search): `spellcheck=false`, `autocorrect="off"`, `autocapitalize="none"`
- `submit/+page.svelte` new-player display name: `spellcheck=false`, `autocorrect="off"` (kept default capitalization since real names are usually capitalized)
- `submit/+page.svelte` new-player username: `spellcheck=false`, `autocorrect="off"`, `autocapitalize="none"`

Closes #218

## Test plan
- [ ] Open the submit-match page in macOS Safari, type initials in the team-member filter — no red underlines.
- [ ] Open the "New player" dialog, type a short display name & handle in macOS Safari — no red underlines.
- [ ] Repeat on iOS Safari and confirm the player filter and username inputs do not capitalize the first letter.
- [ ] Confirm Chrome/Firefox behavior is unchanged.