### PR TITLE
fix(release): unblock release PR and harden changeset validation

### DIFF
--- a/.changeset/mmr-api-distroless-base.md
+++ b/.changeset/mmr-api-distroless-base.md
@@ -1,5 +1,5 @@
 ---
-'mmr-api': patch
+"mmr-api": patch
 ---
 
 Switch the `mmr-api` Docker base image from `debian:bookworm` to `gcr.io/distroless/static-debian12:nonroot`. The previous Debian base shipped without `ca-certificates`, so every outbound HTTPS call from the Go binary failed TLS verification — which silently broke OTLP log/metric/trace export to Grafana Cloud (since the SDK's error reporting is itself routed through the broken slog→OTel pipeline). Distroless static includes a CA bundle, runs as non-root, and shrinks the image to ~42 MB. The build now uses `CGO_ENABLED=0` since `mmr-api`'s dependencies are all pure Go.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -18,23 +18,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Require changeset for releaseable changes
+      - name: Check changesets
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
         run: |
+          # Decision matrix:
+          #   no-release label + changeset present       → fail (mutually exclusive)
+          #   no-release label + no changeset            → pass
+          #   no label        + changeset present        → validate; fail if invalid
+          #   no label        + releaseable code, none   → fail (missing changeset)
+          #   no label        + only non-releaseable     → pass
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          # Match .changeset/<name>.md, excluding the directory's README and config files like config.json.
+          pr_changesets="$(echo "$changed_files" | grep -P '^\.changeset/.+\.md$' | grep -v '^\.changeset/README\.md$' || true)"
+
           if echo "$PR_LABELS" | jq -e '.[] | select(.name == "no-release")' >/dev/null; then
+            if [ -n "$pr_changesets" ]; then
+              echo "This pull request is labeled 'no-release' but includes a changeset:"
+              echo "$pr_changesets"
+              echo "Remove the changeset or remove the 'no-release' label."
+              exit 1
+            fi
             exit 0
           fi
 
-          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          if [ -n "$pr_changesets" ]; then
+            xargs -r node scripts/release/validate-changesets.mjs <<< "$pr_changesets"
+            exit 0
+          fi
 
           if ! echo "$changed_files" | grep -qE '^(frontend/|api/|mmr-api/)'; then
-            exit 0
-          fi
-
-          if echo "$changed_files" | grep -P '^\.changeset/.+\.md$' | grep -vq '^\.changeset/README\.md$'; then
             exit 0
           fi
 

--- a/scripts/release/apply-changesets.mjs
+++ b/scripts/release/apply-changesets.mjs
@@ -13,11 +13,12 @@ export function parseFrontmatter(content) {
   for (const line of match[1].split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    const m = trimmed.match(/^"?([^"]+?)"?:\s*(major|minor|patch)\s*$/);
+    const m = trimmed.match(/^(?:"([^"]+)"|'([^']+)'|([^"':\s][^:]*?)):\s*(major|minor|patch)\s*$/);
     if (!m) {
       throw new Error(`Invalid changeset frontmatter line: ${line}`);
     }
-    bumps[m[1]] = m[2];
+    const name = m[1] ?? m[2] ?? m[3];
+    bumps[name] = m[4];
   }
 
   if (Object.keys(bumps).length === 0) {

--- a/scripts/release/apply-changesets.test.mjs
+++ b/scripts/release/apply-changesets.test.mjs
@@ -24,6 +24,13 @@ describe("parseFrontmatter", () => {
     assert.equal(result.description, "Some change.");
   });
 
+  it("parses single-quoted keys", () => {
+    const content = "---\n'mmr-api': patch\n---\n\nSome change.";
+    const result = parseFrontmatter(content);
+    assert.deepEqual(result.bumps, bumps({ "mmr-api": "patch" }));
+    assert.equal(result.description, "Some change.");
+  });
+
   it("parses multiple components", () => {
     const content = '---\n"frontend": minor\n"api": patch\n---\n\nMulti bump.';
     const result = parseFrontmatter(content);

--- a/scripts/release/validate-changesets.mjs
+++ b/scripts/release/validate-changesets.mjs
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseFrontmatter } from "./apply-changesets.mjs";
+import { components } from "./components.mjs";
+
+export function validateChangesetFile(filePath, knownComponents) {
+  const content = fs.readFileSync(filePath, "utf8");
+  const { bumps } = parseFrontmatter(content);
+  const errors = [];
+  for (const name of Object.keys(bumps)) {
+    if (!knownComponents.has(name)) {
+      errors.push(`Unknown component "${name}"`);
+    }
+  }
+  return errors;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const knownComponents = new Set(components.map((c) => c.name));
+  const files = process.argv.slice(2).filter((f) => f.endsWith(".md") && path.basename(f) !== "README.md");
+
+  if (files.length === 0) {
+    console.log("No changeset files to validate.");
+    process.exit(0);
+  }
+
+  let failed = false;
+  for (const file of files) {
+    const base = path.basename(file);
+    try {
+      const errors = validateChangesetFile(file, knownComponents);
+      if (errors.length > 0) {
+        failed = true;
+        for (const err of errors) console.error(`${base}: ${err}`);
+      }
+    } catch (err) {
+      failed = true;
+      console.error(`${base}: ${err.message}`);
+    }
+  }
+
+  if (failed) {
+    console.error("");
+    console.error(`Known components: ${[...knownComponents].join(", ")}`);
+    process.exit(1);
+  }
+
+  console.log(`Validated ${files.length} changeset file(s).`);
+}


### PR DESCRIPTION
## Summary

The release-pr workflow on `main` is failing with `Unknown component "'mmr-api'" in mmr-api-distroless-base.md` ([run](https://github.com/office-rivals/mmr-project/actions/runs/25623392266/job/75214015407)). The changeset added in #243 used single-quoted YAML (`'mmr-api': patch`), which the frontmatter parser in `scripts/release/apply-changesets.mjs` captured literally — quotes included — because its regex only stripped double quotes.

This PR fixes the immediate failure and adds a guard so it can't happen again:

- **Unblock the release PR** — switch the changeset key to double quotes.
- **Parser** — accept double-quoted, single-quoted, and unquoted keys explicitly. New unit test covers the single-quote case.
- **`scripts/release/validate-changesets.mjs`** (new) — parses frontmatter and asserts every component name exists in `components.mjs`. Accepts file paths as args so it can be scoped to a PR's changesets.
- **`changeset-check.yml`** — consolidated into a single "Check changesets" step:
  - `no-release` label + a changeset present → fail (mutually exclusive).
  - Otherwise: validate changesets touched in this PR, then enforce presence when releaseable code changed.

## Test plan

- [x] `node --test scripts/release/apply-changesets.test.mjs` (26/26 pass)
- [x] `node scripts/release/validate-changesets.mjs .changeset/mmr-api-distroless-base.md` exits 0
- [x] Validator on a synthetic file with `'unknown-thing': patch` exits 1 with `Unknown component "unknown-thing"`
- [ ] Changeset Check workflow passes on this PR
- [ ] After merge: release-pr workflow on main succeeds and opens the release PR