### PR TITLE
fix(mmr-api): bake release version into binary for OTel service.version

### DIFF
--- a/.changeset/mmr-api-service-version.md
+++ b/.changeset/mmr-api-service-version.md
@@ -1,0 +1,5 @@
+---
+'mmr-api': patch
+---
+
+Bake the released version into the `mmr-api` binary so OpenTelemetry resource attributes report the actual `service.version` (e.g. `1.1.2`) instead of the hardcoded `dev`. The Dockerfile now accepts a `VERSION` build arg that is injected via `-ldflags "-X main.version=…"`, and the deploy workflow forwards `inputs.version`. Without this, every emitted log/metric/trace from the deployed `mmr-api` was tagged `service_version=dev`, which made it impossible to attribute production telemetry to a specific release.

--- a/.changeset/mmr-api-service-version.md
+++ b/.changeset/mmr-api-service-version.md
@@ -1,5 +1,5 @@
 ---
-'mmr-api': patch
+"mmr-api": patch
 ---
 
 Bake the released version into the `mmr-api` binary so OpenTelemetry resource attributes report the actual `service.version` (e.g. `1.1.2`) instead of the hardcoded `dev`. The Dockerfile now accepts a `VERSION` build arg that is injected via `-ldflags "-X main.version=…"`, and the deploy workflow forwards `inputs.version`. Without this, every emitted log/metric/trace from the deployed `mmr-api` was tagged `service_version=dev`, which made it impossible to attribute production telemetry to a specific release.

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -69,5 +69,7 @@ jobs:
         with:
           appSourcePath: ${{ github.workspace }}/mmr-api
           acrName: ${{ secrets.ACR_NAME }}
+          buildArguments: |
+            VERSION=${{ inputs.version }}
           containerAppName: ${{ secrets.MMR_API_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}

--- a/mmr-api/Dockerfile
+++ b/mmr-api/Dockerfile
@@ -1,11 +1,13 @@
 ARG GO_VERSION=1
 FROM golang:${GO_VERSION}-bookworm AS builder
 
+ARG VERSION=dev
+
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /run-app .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o /run-app .
 
 
 FROM gcr.io/distroless/static-debian12:nonroot


### PR DESCRIPTION
## Summary
- Pass the released version through the Dockerfile via `-ldflags "-X main.version=${VERSION}"` so OTel reports `service.version` instead of the hardcoded `dev`.
- Forward `inputs.version` from `deploy-release.yml` as the `VERSION` build arg.

## Why
Production telemetry from `mmr-api` was being emitted with `service_version=dev`, so it was impossible to correlate logs/metrics/traces with a specific release. The .NET `mmr-project-api` already reports the real version (e.g. `1.1.0.0`); the Go service was the only laggard.

## Test plan
- [ ] CI green (changeset validation, mmr-api tests).
- [ ] After merge + release, run `Deploy Release` for `mmr-api` and verify `target_info{service_name="mmr-api", deployment_environment="production"}` shows `service_version=<released version>` in Grafana Cloud.
- [ ] Local builds without the `VERSION` build arg still produce a working binary (`service_version=dev`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The service now properly embeds its release version during compilation, ensuring that OpenTelemetry observability data—including logs, metrics, and traces—displays the correct release version instead of a generic "dev" placeholder. This enables more accurate monitoring, debugging, and tracking of service behavior across different releases in your production environment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/office-rivals/mmr-project/pull/248)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->