### PR TITLE
feat(mmr-api): add GET /health endpoint

### DIFF
--- a/.changeset/mmr-api-health-endpoint.md
+++ b/.changeset/mmr-api-health-endpoint.md
@@ -1,0 +1,5 @@
+---
+'mmr-api': patch
+---
+
+Add a `GET /health` endpoint to `mmr-api` that returns `200 OK`. The access-log middleware already excluded `/health` from logging in anticipation of this route, but no handler was registered, so probes pointed at it would 404 instead. With this in place, the Container App liveness/readiness probes can target `/health` cleanly.

--- a/.changeset/mmr-api-health-endpoint.md
+++ b/.changeset/mmr-api-health-endpoint.md
@@ -1,5 +1,5 @@
 ---
-'mmr-api': patch
+"mmr-api": patch
 ---
 
 Add a `GET /health` endpoint to `mmr-api` that returns `200 OK`. The access-log middleware already excluded `/health` from logging in anticipation of this route, but no handler was registered, so probes pointed at it would 404 instead. With this in place, the Container App liveness/readiness probes can target `/health` cleanly.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ export OTEL_EXPORTER_OTLP_HEADERS="Authorization=..."   # if your backend requir
 export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=local-$USER"
 ```
 
+### Production environment variables (mmr-api)
+
+The Container App running `mmr-api` should also have:
+
+- `GIN_MODE=release` — switches Gin out of its default debug mode so it doesn't log `[GIN-debug]` warnings or print routes on startup.
+
+## Health checks
+
+`mmr-api` exposes `GET /health` returning `200 OK`. The endpoint is excluded from the access log and is intended as the liveness/readiness probe target for the `mmr-api-prod` Container App.
+
 ## Testing
 
 - API tests using Bruno collection

--- a/mmr-api/server/router.go
+++ b/mmr-api/server/router.go
@@ -28,6 +28,10 @@ func NewRouter() *gin.Engine {
 		}
 	}
 
+	router.GET("/health", func(ctx *gin.Context) {
+		ctx.Status(http.StatusOK)
+	})
+
 	router.GET("/swagger", func(ctx *gin.Context) {
 		ctx.Redirect(http.StatusPermanentRedirect, "/swagger/index.html")
 	})


### PR DESCRIPTION
## Summary
- Register `GET /health` returning `200 OK` so probes can target it without 404ing.
- Document the endpoint and the required `GIN_MODE=release` env var on the Container App.

## Why
The access-log middleware (`mmr-api/middleware/access_log.go:14`) already excludes `/health` from logging, anticipating a probe endpoint — but no handler was ever registered. Anything currently pointed at `/health` (Azure Container App probes, uptime checks) is logged as a 404. This closes the gap with a one-liner.

## Operational follow-up (do after this merges and deploys)
- [ ] Wire the `mmr-api-prod` Container App liveness/readiness probes to `/health` (`az containerapp update --probe …` or in the Azure Portal).
- [ ] `GIN_MODE=release` is already set on `mmr-api-prod` (revision `mmr-api-prod--0000012`) — keep it.
- Scale-to-zero stays as-is; nothing changes there.

## Test plan
- [ ] CI green.
- [ ] After merge + deploy, `curl https://<mmr-api>/health` returns 200 and the request is *not* in the access log.