### PR TITLE
fix(release): only accept canonical Changesets frontmatter quoting

### DIFF
--- a/.changeset/submit-page-name-priority.md
+++ b/.changeset/submit-page-name-priority.md
@@ -1,5 +1,5 @@
 ---
-'frontend': patch
+"frontend": patch
 ---
 
 Fix submit-page preview to render the same player name (short handle / username) as every other match card. The preview now populates both `displayName` and `username` and lets the match-card pick its own priority, so a player previously shown as `Foo Bar` in the preview now correctly matches the `foob` rendered after submit.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -30,7 +30,12 @@ jobs:
           #   no label        + changeset present        → validate; fail if invalid
           #   no label        + releaseable code, none   → fail (missing changeset)
           #   no label        + only non-releaseable     → pass
-          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          # Use three-dot diff so the comparison is "merge-base...HEAD" — only files this PR
+          # actually changed, not files that diverged on main since the branch point. Without
+          # this, a stale PR branch reports past-release changesets as "added", and
+          # validate-changesets.mjs ENOENTs trying to read them. --diff-filter=ACMRT also
+          # excludes self-deletions on the PR side.
+          changed_files="$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA"..."$HEAD_SHA")"
           # Match .changeset/<name>.md, excluding the directory's README and config files like config.json.
           pr_changesets="$(echo "$changed_files" | grep -P '^\.changeset/.+\.md$' | grep -v '^\.changeset/README\.md$' || true)"
 

--- a/scripts/release/apply-changesets.mjs
+++ b/scripts/release/apply-changesets.mjs
@@ -13,12 +13,12 @@ export function parseFrontmatter(content) {
   for (const line of match[1].split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    const m = trimmed.match(/^(?:"([^"]+)"|'([^']+)'|([^"':\s][^:]*?)):\s*(major|minor|patch)\s*$/);
+    const m = trimmed.match(/^(?:"([^"]+)"|([^"':\s][^:]*?)):\s*(major|minor|patch)\s*$/);
     if (!m) {
       throw new Error(`Invalid changeset frontmatter line: ${line}`);
     }
-    const name = m[1] ?? m[2] ?? m[3];
-    bumps[name] = m[4];
+    const name = m[1] ?? m[2];
+    bumps[name] = m[3];
   }
 
   if (Object.keys(bumps).length === 0) {

--- a/scripts/release/apply-changesets.test.mjs
+++ b/scripts/release/apply-changesets.test.mjs
@@ -24,11 +24,9 @@ describe("parseFrontmatter", () => {
     assert.equal(result.description, "Some change.");
   });
 
-  it("parses single-quoted keys", () => {
+  it("rejects single-quoted keys", () => {
     const content = "---\n'mmr-api': patch\n---\n\nSome change.";
-    const result = parseFrontmatter(content);
-    assert.deepEqual(result.bumps, bumps({ "mmr-api": "patch" }));
-    assert.equal(result.description, "Some change.");
+    assert.throws(() => parseFrontmatter(content), /Invalid changeset frontmatter line/);
   });
 
   it("parses multiple components", () => {


### PR DESCRIPTION
## Summary
- Tighten `parseFrontmatter` to only accept double-quoted (`"name": bump`) and unquoted (`name: bump`) keys — the two forms `@changesets/cli` emits and that [`.changeset/README.md`](.changeset/README.md) documents. Single-quoted keys are now rejected.
- Convert the pending [`.changeset/submit-page-name-priority.md`](.changeset/submit-page-name-priority.md) to double quotes so it stays parseable.
- Switch the `changeset-check` workflow to **three-dot diff** (`BASE...HEAD`) so it compares from the merge-base, not the current main tip. Without this, any PR branched before a release sees the consumed changesets reported as "added" and `validate-changesets.mjs` ENOENTs trying to read them. Also adds `--diff-filter=ACMRT` to exclude self-deletions.

## Why
[#248](https://github.com/office-rivals/mmr-project/pull/248) added a changeset with `'mmr-api': patch` and the validator passed it. The recently-added single-quote handling in [a0c0687](https://github.com/office-rivals/mmr-project/commit/a0c0687) was the immediate fix for an earlier crash, but it leaves the project accepting three subtly different syntaxes when only two are canonical Changesets format. Pinning to the canonical forms now means new changesets stay consistent with what `@changesets/cli` would generate.

The workflow change came from a real failure on [#241](https://github.com/office-rivals/mmr-project/pull/241): its branch base is older than the recent release commit, so `git diff BASE..HEAD` listed `bump-svelte-clerk.md` and `otel-grafana-cloud.md` (consumed by [#247](https://github.com/office-rivals/mmr-project/pull/247)) as added, and the validator crashed reading them.

## Test plan
- [x] `node --test scripts/release/*.test.mjs` — 39/39 pass; `parses single-quoted keys` test flipped to `rejects single-quoted keys`.
- [x] Manual smoke test of `validate-changesets.mjs` — single-quoted file exits 1 with `Invalid changeset frontmatter line: 'frontend': patch`; double-quoted exits 0.
- [x] Reproduced #241's failure locally: two-dot diff against #241's base lists three changesets including the deleted ones; three-dot diff lists only `eslint-flat-config-upgrade.md`.
- [ ] CI `changeset-check` green on this PR.