### PR TITLE
fix(auth): unblock GitHub OAuth sign-up via Clerk transfer

### DIFF
--- a/.changeset/github-oauth-signup.md
+++ b/.changeset/github-oauth-signup.md
@@ -1,0 +1,5 @@
+---
+"frontend": patch
+---
+
+Fix GitHub (and other OAuth) sign-up getting stuck on `external_account_not_found`. Adds a `/sign-up` route mounting Clerk's `<SignUp />` component so the prebuilt `<SignIn />` flow can complete the OAuth → sign-up transfer for first-time users. Also allowlists `/sign-up` in the server-side auth guard so the redirect isn't bounced back to `/login`.

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -8,7 +8,9 @@ import { env } from '$env/dynamic/private';
 const authGuard: Handle = async ({ event, resolve }) => {
   const { userId } = event.locals.auth();
 
-  const isNonAuthedPathname = event.url.pathname.startsWith('/login');
+  const isNonAuthedPathname =
+    event.url.pathname.startsWith('/login') ||
+    event.url.pathname.startsWith('/sign-up');
   if (!userId && !isNonAuthedPathname) {
     return redirect(303, '/login');
   }

--- a/frontend/src/routes/sign-up/+page.svelte
+++ b/frontend/src/routes/sign-up/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { SignUp } from 'svelte-clerk';
+</script>
+
+<div class="flex min-h-screen items-center justify-center">
+  <SignUp />
+</div>


### PR DESCRIPTION
## Summary

Users hitting "Sign in with GitHub" with a fresh GitHub account were getting stuck with an `external_account_not_found` error.

This is Clerk's normal handoff signal: when an OAuth identity has no matching Clerk user, the prebuilt `<SignIn />` returns `verification.status: "transferable"` and expects the app to host a `<SignUp />` at `signUpUrl` (default `/sign-up`) so it can finish the flow with `signUp.create({ transfer: true })`.

This repo had:
- No `/sign-up` route — only `/login` with `<SignIn />`.
- An `authGuard` in `hooks.server.ts` that redirected everything outside `/login` to `/login` for unauthenticated users, so even a fallback redirect couldn't land.

Result: the OAuth verification was created, sat idle, and expired — every GitHub first-timer was stuck.

## Changes

- Add `frontend/src/routes/sign-up/+page.svelte` mounting `<SignUp />` from `svelte-clerk`. Clerk handles the `transfer: true` step automatically when the component mounts on a transferable session.
- Allowlist `/sign-up` in `authGuard` so authenticated and unauthenticated redirects behave like `/login`.
- Add changeset (`frontend: patch`).

## Test plan

- [ ] Open `/login` while signed out → confirm the existing sign-in UI still works for email + existing GitHub-linked users.
- [ ] Sign in with a GitHub account that has never signed in here → confirm flow now lands on `/sign-up`, completes the transfer, and creates a Clerk user without the `external_account_not_found` error.
- [ ] Visit `/sign-up` while already signed in → confirm redirect to `/`.
- [ ] Visit a random authed route (e.g. `/admin`) while signed out → confirm redirect to `/login` (unchanged behaviour).

## Worth verifying in Clerk Dashboard

Under **User & Authentication → SSO Connections → GitHub**, make sure GitHub is enabled for sign-up (not just sign-in), and the instance isn't in restricted/allowlist mode that blocks new sign-ups. If self-service GitHub sign-up is *not* desired given the v3 invite-based league flow, the cleaner option is to remove GitHub from the `<SignIn />` configuration rather than show it and let users get stuck.