### PR TITLE
feat(mmr-api): add Container App liveness + readiness probes

### DIFF
--- a/.changeset/mmr-api-probes.md
+++ b/.changeset/mmr-api-probes.md
@@ -1,0 +1,5 @@
+---
+"mmr-api": patch
+---
+
+Wire up Container App liveness and readiness probes for `mmr-api` pointing at `GET /health` on port 8080. The deploy workflow now patches the Container App template after each `mmr-api` deploy so the probes are reapplied on every release: liveness restarts the container after 3 consecutive 30-second failures; readiness gates traffic on `/health` returning 200 within 10-second windows. Without probes, Container Apps treats every revision as healthy from the moment the process starts and never restarts a stuck instance, so a wedged `mmr-api` would silently keep serving (or failing) until manually intervened.

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -73,3 +73,38 @@ jobs:
             VERSION=${{ inputs.version }}
           containerAppName: ${{ secrets.MMR_API_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}
+
+      - name: Apply mmr-api health probes
+        if: inputs.component == 'mmr-api'
+        env:
+          APP: ${{ secrets.MMR_API_CONTAINER_APP_NAME }}
+          RG: ${{ secrets.RESOURCE_GROUP }}
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp --suffix=.yaml)
+          az containerapp show -n "$APP" -g "$RG" -o yaml > "$tmp"
+
+          yq -i '
+            .properties.template.containers[0].probes = [
+              {
+                "type": "Liveness",
+                "httpGet": { "path": "/health", "port": 8080, "scheme": "HTTP" },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 30,
+                "timeoutSeconds": 3,
+                "failureThreshold": 3,
+                "successThreshold": 1
+              },
+              {
+                "type": "Readiness",
+                "httpGet": { "path": "/health", "port": 8080, "scheme": "HTTP" },
+                "initialDelaySeconds": 5,
+                "periodSeconds": 10,
+                "timeoutSeconds": 3,
+                "failureThreshold": 3,
+                "successThreshold": 1
+              }
+            ]
+          ' "$tmp"
+
+          az containerapp update -n "$APP" -g "$RG" --yaml "$tmp" --output none


### PR DESCRIPTION
## Summary

Wire up liveness and readiness probes for the `mmr-api` Container App pointing at `GET /health` on port 8080. The `/health` endpoint is the one added in [mmr-api@1.1.2](https://github.com/office-rivals/mmr-project/releases/tag/mmr-api%401.1.2) (#249), which returns an unconditional 200 OK.

Without probes, Container Apps marks every revision healthy the moment the process starts and never restarts a stuck instance — a wedged `mmr-api` would silently keep serving (or failing) until manual intervention.

## How it works

A new `Apply mmr-api health probes` step runs after the existing `azure/container-apps-deploy-action@v2` (only when `inputs.component == 'mmr-api'`). It:
1. `az containerapp show -o yaml` — read the current template.
2. `yq` injects a `probes` array on `properties.template.containers[0]`.
3. `az containerapp update --yaml` reapplies the full template.

This pattern was chosen over passing probes through the deploy action (which doesn't expose them) and over doing a one-shot manual `az` call (which would drift the moment the action creates a new revision). Reapplying on every deploy keeps the live config in lockstep with what's in this workflow.

### Probe config

| | Path | Period | Initial | Timeout | Failure threshold |
|---|---|---|---|---|---|
| Liveness | `/health` | 30s | 10s | 3s | 3 |
| Readiness | `/health` | 10s | 5s | 3s | 3 |

- Liveness is loose enough not to flap on a transient blip; readiness is tighter so we don't route traffic to a pod still warming up.
- `mmr-api` is a Go binary on distroless; boot is sub-second, so no startup probe is needed.
- `successThreshold: 1` per the [Container Apps probe constraints](https://learn.microsoft.com/azure/container-apps/health-probes).

### Changeset

Adds `.changeset/mmr-api-probes.md` (`mmr-api: patch`) so the next release PR captures this in the changelog. The deploy workflow change is gated on `component == 'mmr-api'`, so it only fires when that component is rolled out — first effective on the next `mmr-api` deploy after this PR + the resulting release PR merge.

## Test plan

- [ ] Merge this, let the release PR pick it up, merge that, then dispatch `Deploy Release` with `component=mmr-api` and the new version.
- [ ] After the run, `az containerapp show -n <app> -g <rg> --query 'properties.template.containers[0].probes'` shows the two probes.
- [ ] In the Azure portal: Revisions blade shows the new revision as `Healthy`.
- [ ] Optional smoke: temporarily break `/health` (e.g. return 503), redeploy, confirm the revision flips Unhealthy and rolls back.