### PR TITLE
ci(e2e): rewrite workflow to match the post-isolation Playwright design

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,19 @@ jobs:
         working-directory: ./frontend
         run: npx playwright install --with-deps chromium
 
+      # Bring the e2e Postgres up explicitly so it's already accepting
+      # connections by the time Playwright launches the .NET API (which
+      # migrates the DB on startup). Playwright's globalSetup races with
+      # webServer launch — the docker-compose `up -d` is asynchronous and
+      # the API would otherwise crash on a refused connection.
+      - name: Start e2e Postgres
+        working-directory: ./local-development
+        run: |
+          docker compose -f docker-compose.e2e.yml up -d
+          for i in {1..30}; do
+            pg_isready -h localhost -p 5433 -U postgres && break || sleep 1
+          done
+
       # `npm run e2e` is fully self-contained: playwright.config.ts uses
       # `global-services.setup.ts` to bring up the dedicated e2e Postgres via
       # docker-compose (port 5433) and Playwright's webServer block starts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       # ---------------- mmr-api (Go) ----------------
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: mmr-api/go.mod
       - name: Build mmr-api
         working-directory: ./mmr-api
         run: go build -o /tmp/mmr-api .

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,114 +12,58 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_PASSWORD: this_is_a_hard_password1337
-          POSTGRES_DB: mmr_project
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-
     steps:
       - uses: actions/checkout@v6
 
-      # ---------------- mmr-api (Go) ----------------
       - uses: actions/setup-go@v6
         with:
           go-version-file: mmr-api/go.mod
-      - name: Build mmr-api
-        working-directory: ./mmr-api
-        run: go build -o /tmp/mmr-api .
-      - name: Run mmr-api
-        working-directory: ./mmr-api
-        env:
-          ADMIN_SECRET: e2e-admin-secret
-        run: |
-          /tmp/mmr-api &
-          echo $! > /tmp/mmr-api.pid
-          for i in {1..30}; do
-            curl -sf http://localhost:8080/swagger/index.html > /dev/null && break || sleep 1
-          done
 
-      # ---------------- API (.NET) ----------------
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
-      - name: Build API
-        working-directory: ./api/MMRProject.Api
-        run: dotnet build --configuration Release
-      - name: Run API
-        working-directory: ./api/MMRProject.Api
-        env:
-          ConnectionStrings__ApiDbContext: Host=localhost;Database=mmr_project;Username=postgres;Password=this_is_a_hard_password1337
-          Migration__Enabled: "true"
-          MMRCalculationAPI__BaseUrl: http://localhost:8080
-          MMRCalculationAPI__ApiKey: e2e-admin-secret
-          Admin__Secret: e2e-admin-secret
-          Authorization__Issuer: ${{ secrets.E2E_CLERK_ISSUER }}
-        run: |
-          dotnet run --no-build --configuration Release &
-          echo $! > /tmp/api.pid
-          for i in {1..60}; do
-            curl -sf http://localhost:8081/swagger/index.html > /dev/null && break || sleep 2
-          done
 
-      # ---------------- Apply seed ----------------
-      - name: Apply seed
-        env:
-          IDENTITY_USER_ID: ${{ secrets.E2E_IDENTITY_USER_ID }}
-          USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
-        run: ./scripts/seed-local.sh
-
-      # ---------------- Frontend + Playwright ----------------
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - name: Install
+
+      - name: Install frontend deps
         working-directory: ./frontend
         run: npm ci
+
       - name: Install Playwright browsers
         working-directory: ./frontend
         run: npx playwright install --with-deps chromium
-      - name: Build frontend
-        working-directory: ./frontend
-        env:
-          PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.E2E_CLERK_PUBLISHABLE_KEY }}
-          API_BASE_PATH: http://localhost:8081
-        run: npm run build
-      - name: Start frontend
-        working-directory: ./frontend
-        env:
-          PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.E2E_CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
-          API_BASE_PATH: http://localhost:8081
-          PORT: "5173"
-        run: |
-          npm run start &
-          echo $! > /tmp/frontend.pid
-          for i in {1..30}; do
-            curl -sf http://localhost:5173/login > /dev/null && break || sleep 1
-          done
 
+      # `npm run e2e` is fully self-contained: playwright.config.ts uses
+      # `global-services.setup.ts` to bring up the dedicated e2e Postgres via
+      # docker-compose (port 5433) and Playwright's webServer block starts
+      # mmr-api (8090), .NET API (8091) and Vite (5180) on isolated ports.
+      # The seed runs from `global.setup.ts` against the same Postgres.
+      # All this CI step has to do is supply the secrets that those child
+      # processes need — Playwright merges them into each webServer env.
       - name: Run Playwright
         working-directory: ./frontend
         env:
+          # Test user (sign-in via Clerk hosted UI)
           E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
           E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
           E2E_IDENTITY_USER_ID: ${{ secrets.E2E_IDENTITY_USER_ID }}
-          DB_HOST: localhost
-          DB_PORT: "5432"
-          DB_NAME: mmr_project
-          DB_USER: postgres
-          DB_PASS: this_is_a_hard_password1337
+
+          # mmr-api required env
+          ADMIN_SECRET: e2e-admin-secret
+
+          # .NET API required env (Clerk JWT issuer comes from secrets)
+          Admin__Secret: e2e-admin-secret
+          MMRCalculationAPI__ApiKey: e2e-admin-secret
+          Authorization__Issuer: ${{ secrets.E2E_CLERK_ISSUER }}
+          Migration__Enabled: "true"
+
+          # Frontend Clerk wiring
+          PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.E2E_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
         run: npm run e2e
 
       - name: Upload Playwright report


### PR DESCRIPTION
## Summary

The e2e workflow has been structurally non-functional since [7a49292](https://github.com/office-rivals/mmr-project/commit/7a49292) (`test(e2e): isolate e2e stack on dedicated ports`, 2026-05-01). That commit moved every e2e dependency — Postgres, mmr-api, .NET API, Vite — onto a parallel set of isolated ports owned by Playwright itself (`playwright.config.ts` `webServer` + `global-services.setup.ts`). The CI workflow was never updated to match.

What CI was doing instead, until now:

1. Spinning up a GitHub Actions Postgres service on **5432**, while Playwright wants Postgres on **5433** (its own docker-compose stack with project name `mmr-e2e`).
2. Manually building and starting `mmr-api` on **8080**, the .NET API on **8081**, and Vite on **5173** — all of which Playwright then ignored and re-started on **8090 / 8091 / 5180** via `webServer`.
3. Seeding the **5432** Actions Postgres with `scripts/seed-local.sh`. That seed went nowhere useful: Playwright's `global.setup.ts` runs the same seed again at test time, against the **5433** Postgres.
4. Calling `npm run e2e` with only `E2E_USER_*` and the Actions-Postgres `DB_*` in the step env — so when Playwright spawned its own `mmr-api` child it had no `ADMIN_SECRET`, the .NET API had no `Admin__Secret` / `MMRCalculationAPI__ApiKey` / `Authorization__Issuer`, and the Vite dev server had no `PUBLIC_CLERK_PUBLISHABLE_KEY`. mmr-api crashed at startup, and even after fixing that the .NET API and Vite kept missing their config.

In other words: even with all the `E2E_*` repo secrets correctly populated, the previous workflow could not have run a green e2e — every secret was being passed to the wrong (dead-code) services and never reaching the ones Playwright actually launches.

## Changes

- **Drop the legacy orchestration entirely**: no Actions Postgres service, no manual mmr-api/.NET API/Vite builds, no separate seed step. Playwright already owns all of that since 7a49292.
- **`go-version-file: mmr-api/go.mod`** instead of the hardcoded `1.23` — `mmr-api` already needs 1.25.
- **Start the e2e Postgres explicitly before `npm run e2e`.** `playwright.config.ts` brings it up via `global-services.setup.ts`, but in CI that races with `webServer` launches: the .NET API tries to run its startup migration against `localhost:5433` before docker-compose has finished pulling/starting the container, crashes the webServer, and Playwright times out. Doing `docker compose -f local-development/docker-compose.e2e.yml up -d` + `pg_isready` in a dedicated step ahead of `npm run e2e` removes the race without touching the Playwright config. Locally this is invisible because the e2e compose stack is usually already up.
- **Move the right env vars onto the `Run Playwright` step**: `ADMIN_SECRET`, `Admin__Secret`, `MMRCalculationAPI__ApiKey`, `Authorization__Issuer`, `Migration__Enabled`, `PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`. Playwright merges process.env into each `webServer.env`, so children pick them up.

## Known prerequisite (not in this PR)

The `E2E_*` repository secrets aren't currently populated. The workflow references them via `${{ secrets.E2E_* }}`, so without setting them the frontend `webServer` still fails with `Publishable key is missing`. Required:

- `E2E_USER_EMAIL`
- `E2E_USER_PASSWORD`
- `E2E_IDENTITY_USER_ID`
- `E2E_CLERK_ISSUER`
- `E2E_CLERK_PUBLISHABLE_KEY`
- `E2E_CLERK_SECRET_KEY`

Values for the test user are documented in `frontend/.env.e2e.example`; the Clerk keys come from the Clerk dev instance dashboard. Without these, `npm run e2e` works locally (where these come from `frontend/.env`/`.env.e2e`) but the CI workflow can't fully verify end-to-end.

## Test plan

- [ ] Populate the six `E2E_*` repo secrets.
- [ ] Dispatch `E2E` on this branch and confirm it goes green.