### PR TITLE
ci: bump azure/login, enable actions Dependabot, auto-changeset deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     directory: "/api"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependency-changeset.yml
+++ b/.github/workflows/dependency-changeset.yml
@@ -1,0 +1,85 @@
+name: Dependency Changeset
+
+# Auto-generates a patch changeset on dependency PRs (any PR labeled
+# `dependencies`, which Dependabot applies automatically) so the regular
+# release pipeline picks them up without manual intervention.
+#
+# Scope: only same-repo PRs (Dependabot opens its branches in this repo,
+# not from a fork). Fork PRs are skipped — add a changeset manually.
+#
+# Limitation: pushes use the default GITHUB_TOKEN, which does NOT trigger
+# downstream workflows. After this workflow pushes, the previously-failed
+# Changeset Check must be re-run manually (one click in the PR's Checks
+# tab). Swap `secrets.GITHUB_TOKEN` for a PAT or GitHub App token below
+# to make the re-trigger automatic.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  generate:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      !contains(github.event.pull_request.labels.*.name, 'no-release') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate changeset if missing
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Skip if the PR already has its own changeset.
+          existing="$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA"...HEAD \
+              | grep -E '^\.changeset/.+\.md$' \
+              | grep -v '^\.changeset/README\.md$' || true)"
+          if [ -n "$existing" ]; then
+            echo "PR already includes a changeset:"
+            echo "$existing"
+            exit 0
+          fi
+
+          # Map changed paths to releaseable components.
+          changed="$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA"...HEAD)"
+          components=()
+          if echo "$changed" | grep -qE '^frontend/'; then components+=("frontend"); fi
+          if echo "$changed" | grep -qE '^api/';      then components+=("api");      fi
+          if echo "$changed" | grep -qE '^mmr-api/';  then components+=("mmr-api");  fi
+
+          if [ ${#components[@]} -eq 0 ]; then
+            echo "No releaseable component changed — nothing to do."
+            exit 0
+          fi
+
+          changeset_path=".changeset/dependabot-pr-${PR_NUMBER}.md"
+          {
+            echo "---"
+            for c in "${components[@]}"; do
+              printf '"%s": patch\n' "$c"
+            done
+            echo "---"
+            echo
+            printf '%s\n' "$PR_TITLE"
+          } > "$changeset_path"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$changeset_path"
+          git commit -m "chore: auto-generate changeset for #${PR_NUMBER}"
+          git push origin "HEAD:${GITHUB_HEAD_REF}"

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
 
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 


### PR DESCRIPTION
## Summary
- Bump `azure/login@v2` → `azure/login@v3` (pinned to SHA `532459e` for supply-chain hardening) so the Deploy Release workflow moves off Node.js 20 ahead of the GitHub runner deprecation. `azure/container-apps-deploy-action` has no v3 yet, so it stays at `@v2`.
- Add `github-actions` to `.github/dependabot.yml` so future action bumps are proposed automatically.
- New `Dependency Changeset` workflow: any same-repo PR labeled `dependencies` (Dependabot applies this automatically) without a `no-release` label gets a patch changeset added for every releaseable component its diff touches, so dependency bumps flow through the existing release pipeline without manual changeset edits.

## Notes
- The auto-changeset workflow pushes with `GITHUB_TOKEN`, which does not re-trigger Changeset Check. Until that's swapped for a PAT/App token, the previously-failed Changeset Check on a Dependabot PR needs one manual "Re-run" click after the changeset lands.

## Test plan
- [ ] Next `Deploy Release` run for any component completes successfully and no longer warns about `azure/login` using Node.js 20.
- [ ] First Dependabot PR after merge (npm/nuget/gomod/github-actions) gets a `.changeset/dependabot-pr-<n>.md` committed automatically, and a re-run of Changeset Check turns green.