### PR TITLE
ci(dependabot): group OpenTelemetry Go module updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/mmr-api"
     schedule:
       interval: "weekly"
+    groups:
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:


### PR DESCRIPTION
## Summary
- Add an `opentelemetry` group on the gomod ecosystem matching `go.opentelemetry.io/*`. OTel Go modules are designed to be bumped together for compatibility — would have collapsed today's 4–5 individual OTel PRs into one.

Other ecosystems intentionally left alone for now; broader grouping can come in a follow-up.

## Test plan
- [ ] Next weekly Dependabot run produces a single `opentelemetry` PR instead of one per OTel module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to streamline OpenTelemetry package updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/office-rivals/mmr-project/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->