### PR TITLE
Feat: add docker build and release pipelines

### DIFF
--- a/.changeset/cd-pipeline.md
+++ b/.changeset/cd-pipeline.md
@@ -1,0 +1,7 @@
+---
+frontend: patch
+api: patch
+mmr-api: patch
+---
+
+Publish frontend, API, and MMR API images from main using the shared release version.

--- a/.changeset/dependabot-pr-240.md
+++ b/.changeset/dependabot-pr-240.md
@@ -1,5 +1,0 @@
----
-"frontend": patch
----
-
-chore(deps-dev): bump ip-address from 10.1.0 to 10.2.0 in /frontend

--- a/.changeset/dependabot-pr-259.md
+++ b/.changeset/dependabot-pr-259.md
@@ -1,5 +1,0 @@
----
-"frontend": patch
----
-
-chore(deps-dev): bump prettier-plugin-tailwindcss from 0.7.3 to 0.8.0 in /frontend

--- a/.changeset/dependabot-pr-276.md
+++ b/.changeset/dependabot-pr-276.md
@@ -1,5 +1,0 @@
----
-"frontend": patch
----
-
-chore(deps-dev): bump eslint-plugin-svelte from 3.17.1 to 3.18.0 in /frontend

--- a/.changeset/dependabot-pr-279.md
+++ b/.changeset/dependabot-pr-279.md
@@ -1,5 +1,0 @@
----
-"mmr-api": patch
----
-
-chore(deps): bump go.opentelemetry.io/otel/sdk from 1.43.0 to 1.44.0 in /mmr-api

--- a/.changeset/dependabot-pr-280.md
+++ b/.changeset/dependabot-pr-280.md
@@ -1,5 +1,0 @@
----
-"frontend": patch
----
-
-chore(deps-dev): bump @sveltejs/kit from 2.58.0 to 2.61.1 in /frontend

--- a/.changeset/dependabot-pr-283.md
+++ b/.changeset/dependabot-pr-283.md
@@ -1,5 +1,0 @@
----
-"frontend": patch
----
-
-chore(deps-dev): bump @playwright/test from 1.59.1 to 1.60.0 in /frontend

--- a/.changeset/dependabot-pr-284.md
+++ b/.changeset/dependabot-pr-284.md
@@ -1,5 +1,0 @@
----
-"frontend": patch
----
-
-chore(deps): bump svelte-clerk from 1.1.5 to 1.1.9 in /frontend

--- a/.changeset/dependabot-pr-285.md
+++ b/.changeset/dependabot-pr-285.md
@@ -1,5 +1,0 @@
----
-"frontend": patch
----
-
-chore(deps-dev): bump @sveltejs/adapter-auto from 3.3.1 to 7.0.1 in /frontend

--- a/.changeset/dependabot-pr-286.md
+++ b/.changeset/dependabot-pr-286.md
@@ -1,5 +1,0 @@
----
-"mmr-api": patch
----
-
-chore(deps): bump the opentelemetry group in /mmr-api with 7 updates

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,88 @@
+name: cd
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/package.json
+      - api/package.json
+      - api/MMRProject.Api/MMRProject.Api.csproj
+      - mmr-api/package.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read release versions
+        id: versions
+        shell: bash
+        run: |
+          frontend_version=$(node -p "require('./frontend/package.json').version")
+          api_version=$(node -p "require('./api/package.json').version")
+          mmr_api_version=$(node -p "require('./mmr-api/package.json').version")
+
+          if [ "$frontend_version" != "$api_version" ] || [ "$frontend_version" != "$mmr_api_version" ]; then
+            echo "Frontend, API, and MMR API versions must match before publishing images." >&2
+            echo "frontend: $frontend_version" >&2
+            echo "api: $api_version" >&2
+            echo "mmr-api: $mmr_api_version" >&2
+            exit 1
+          fi
+
+          repo=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+
+          echo "version=$frontend_version" >> "$GITHUB_OUTPUT"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          build-args: |
+            PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.CLERK_PUBLISHABLE_KEY }}
+          tags: |
+            ghcr.io/${{ steps.versions.outputs.repo }}/frontend:${{ steps.versions.outputs.version }}
+            ghcr.io/${{ steps.versions.outputs.repo }}/frontend:latest
+
+      - name: Build and push api
+        uses: docker/build-push-action@v6
+        with:
+          context: ./api/MMRProject.Api
+          push: true
+          tags: |
+            ghcr.io/${{ steps.versions.outputs.repo }}/api:${{ steps.versions.outputs.version }}
+            ghcr.io/${{ steps.versions.outputs.repo }}/api:latest
+
+      - name: Build and push mmr-api
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mmr-api
+          push: true
+          build-args: |
+            VERSION=${{ steps.versions.outputs.version }}
+          tags: |
+            ghcr.io/${{ steps.versions.outputs.repo }}/mmr-api:${{ steps.versions.outputs.version }}
+            ghcr.io/${{ steps.versions.outputs.repo }}/mmr-api:latest

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,14 +1,11 @@
-name: Publish docker Images
+name: Publish Docker Images
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - frontend/package.json
-      - api/package.json
-      - api/MMRProject.Api/MMRProject.Api.csproj
-      - mmr-api/package.json
+  workflow_run:
+    workflows:
+      - Publish GitHub Releases
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -16,14 +13,17 @@ permissions:
   packages: write
 
 concurrency:
-  group: cd-${{ github.ref }}
+  group: cd-${{ github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'changeset-release/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Read release versions
         id: versions

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,4 +1,4 @@
-name: cd
+name: Publish docker Images
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,39 @@ docker compose --env-file .env -f docker-compose.local.yml up
 
 Open `http://localhost:3000`. The API is also available at `http://localhost:8081/swagger`.
 
+#### Create the first organization
+
+The deployed UI does not currently include a first-run organization creation
+screen. Create the first organization through the API after signing in locally.
+The authenticated user that creates the organization becomes its `Owner` and
+can then use the admin UI.
+
+1. Open `http://localhost:3000` and sign in with Clerk.
+2. Open your browser devtools console on the local frontend.
+3. Get a Clerk token:
+
+   ```js
+   await window.Clerk.session.getToken()
+   ```
+
+4. Use that token to create the organization through the local API:
+
+   ```bash
+   curl -X POST "http://localhost:8081/api/v3/organizations" \
+     -H "Authorization: Bearer <clerk_token_from_browser>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "Local Organization",
+       "slug": "local-org"
+     }'
+   ```
+
+5. Open `http://localhost:3000/admin`. The organization should be listed there.
+
+The `slug` becomes the organization URL segment, for example
+`http://localhost:3000/local-org`. Avoid reserved slugs such as `admin`,
+`api`, `login`, `join`, `profile`, `settings`, and `submit`.
+
 ## Development
 
 ### Frontend (SvelteKit)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,95 @@ The application uses Clerk for authentication. Follow these steps to get started
    npm run dev
    ```
 
+### Try Locally With Docker Compose
+
+Create a `.env` file next to the compose file with your Clerk values and local secrets:
+
+```bash
+PUBLIC_CLERK_PUBLISHABLE_KEY=<your_clerk_publishable_key>
+CLERK_SECRET_KEY=<your_clerk_secret_key>
+CLERK_ISSUER_URL=<your_clerk_issuer_url>
+POSTGRES_PASSWORD=local-postgres-password
+MMR_ADMIN_SECRET=local-admin-secret
+```
+
+Then run this compose file from the repository root:
+
+```yaml
+name: mmr-project-local
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: mmr_project
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d mmr_project"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mmr-api:
+    image: ghcr.io/andersspringborg/mmr-project/mmr-api:1.2.1
+    restart: unless-stopped
+    environment:
+      ADMIN_SECRET: ${MMR_ADMIN_SECRET}
+      MMR_API_PORT: 8080
+    ports:
+      - "8080:8080"
+
+  api:
+    image: ghcr.io/andersspringborg/mmr-project/api:1.2.1
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mmr-api:
+        condition: service_started
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__ApiDbContext: Host=postgres;Port=5432;Database=mmr_project;Username=postgres;Password=${POSTGRES_PASSWORD}
+      Authorization__Issuer: ${CLERK_ISSUER_URL}
+      Migration__Enabled: "true"
+      MMRCalculationAPI__BaseUrl: http://mmr-api:8080
+      MMRCalculationAPI__ApiKey: ${MMR_ADMIN_SECRET}
+    ports:
+      - "8081:8080"
+
+  frontend:
+    image: ghcr.io/andersspringborg/mmr-project/frontend:1.2.1
+    restart: unless-stopped
+    depends_on:
+      - api
+    environment:
+      NODE_ENV: production
+      ORIGIN: http://localhost:3000
+      API_BASE_PATH: http://api:8080
+      PUBLIC_CLERK_PUBLISHABLE_KEY: ${PUBLIC_CLERK_PUBLISHABLE_KEY}
+      CLERK_SECRET_KEY: ${CLERK_SECRET_KEY}
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres-data:
+```
+
+Save it as `docker-compose.local.yml`, then start everything:
+
+```bash
+docker compose --env-file .env -f docker-compose.local.yml up
+```
+
+Open `http://localhost:3000`. The API is also available at `http://localhost:8081/swagger`.
+
 ## Development
 
 ### Frontend (SvelteKit)

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+
+- Sync release version with frontend and mmr-api.
+
 ## 1.2.0
 
 - Add support for 1v1 leagues, and replace `League.QueueSize` with `League.TeamSize` (the per-team player count) — `QueueSize` was the inverted way to think about the same concept. The queue requires `2 * teamSize` players. Migrating: existing `queue_size` values are halved into the new `team_size` column.

--- a/api/MMRProject.Api/MMRProject.Api.csproj
+++ b/api/MMRProject.Api/MMRProject.Api.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
       <UserSecretsId>6ff8a387-4ab4-424d-a184-7c02b9b6c2fe</UserSecretsId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
 
     <ItemGroup>

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
   "name": "api",
   "private": true,
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.1
+
+- chore(deps-dev): bump ip-address from 10.1.0 to 10.2.0 in /frontend
+- chore(deps-dev): bump prettier-plugin-tailwindcss from 0.7.3 to 0.8.0 in /frontend
+- chore(deps-dev): bump eslint-plugin-svelte from 3.17.1 to 3.18.0 in /frontend
+- chore(deps-dev): bump @sveltejs/kit from 2.58.0 to 2.61.1 in /frontend
+- chore(deps-dev): bump @playwright/test from 1.59.1 to 1.60.0 in /frontend
+- chore(deps): bump svelte-clerk from 1.1.5 to 1.1.9 in /frontend
+- chore(deps-dev): bump @sveltejs/adapter-auto from 3.3.1 to 7.0.1 in /frontend
+
 ## 1.2.0
 
 - Add support for 1v1 leagues, and replace `League.QueueSize` with `League.TeamSize` (the per-team player count) — `QueueSize` was the inverted way to think about the same concept. The queue requires `2 * teamSize` players. Migrating: existing `queue_size` values are halved into the new `team_size` column.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "vite dev --host",

--- a/mmr-api/CHANGELOG.md
+++ b/mmr-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1
+
+- chore(deps): bump go.opentelemetry.io/otel/sdk from 1.43.0 to 1.44.0 in /mmr-api
+- chore(deps): bump the opentelemetry group in /mmr-api with 7 updates
+
 ## 1.2.0
 
 - Add support for 1v1 leagues, and replace `League.QueueSize` with `League.TeamSize` (the per-team player count) — `QueueSize` was the inverted way to think about the same concept. The queue requires `2 * teamSize` players. Migrating: existing `queue_size` values are halved into the new `team_size` column.

--- a/mmr-api/package.json
+++ b/mmr-api/package.json
@@ -1,5 +1,5 @@
 {
   "name": "mmr-api",
   "private": true,
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/scripts/release/apply-changesets.mjs
+++ b/scripts/release/apply-changesets.mjs
@@ -50,6 +50,33 @@ export function incrementVersion(version, bumpType) {
   }
 }
 
+export function syncReleaseGroup(aggregated, groupNames, bumpPriority) {
+  const groupUpdates = groupNames
+    .map((name) => [name, aggregated[name]])
+    .filter(([, update]) => update);
+
+  if (groupUpdates.length === 0) {
+    return;
+  }
+
+  const highestBump = groupUpdates.reduce((highest, [, update]) => {
+    return bumpPriority[update.bumpType] > bumpPriority[highest] ? update.bumpType : highest;
+  }, groupUpdates[0][1].bumpType);
+
+  const changedNames = groupUpdates.map(([name]) => name).join(" and ");
+
+  for (const name of groupNames) {
+    if (aggregated[name]) {
+      aggregated[name].bumpType = highestBump;
+    } else {
+      aggregated[name] = {
+        bumpType: highestBump,
+        descriptions: [`Sync release version with ${changedNames}.`]
+      };
+    }
+  }
+}
+
 export function updateChangelog(changelogPath, version, descriptions) {
   const formatDescription = (description) => {
     const [firstLine, ...rest] = description.split(/\r?\n/);
@@ -122,6 +149,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       }
     }
   }
+
+  syncReleaseGroup(aggregated, ["frontend", "api", "mmr-api"], bumpPriority);
 
   const plannedUpdates = [];
   for (const [name, { bumpType, descriptions }] of Object.entries(aggregated)) {

--- a/scripts/release/apply-changesets.test.mjs
+++ b/scripts/release/apply-changesets.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { parseFrontmatter, incrementVersion, updateChangelog } from "./apply-changesets.mjs";
+import { parseFrontmatter, incrementVersion, syncReleaseGroup, updateChangelog } from "./apply-changesets.mjs";
 
 function bumps(obj) {
   return Object.assign(Object.create(null), obj);
@@ -117,6 +117,58 @@ describe("incrementVersion", () => {
 
   it("throws on invalid bump type", () => {
     assert.throws(() => incrementVersion("1.0.0", "huge"), /Invalid bump type/);
+  });
+});
+
+describe("syncReleaseGroup", () => {
+  const bumpPriority = { major: 3, minor: 2, patch: 1 };
+
+  it("adds missing components using the existing component bump", () => {
+    const aggregated = {
+      frontend: { bumpType: "patch", descriptions: ["Frontend change"] }
+    };
+
+    syncReleaseGroup(aggregated, ["frontend", "api", "mmr-api"], bumpPriority);
+
+    assert.deepEqual(aggregated, {
+      frontend: { bumpType: "patch", descriptions: ["Frontend change"] },
+      api: {
+        bumpType: "patch",
+        descriptions: ["Sync release version with frontend."]
+      },
+      "mmr-api": {
+        bumpType: "patch",
+        descriptions: ["Sync release version with frontend."]
+      }
+    });
+  });
+
+  it("uses the highest bump when multiple grouped components changed", () => {
+    const aggregated = {
+      frontend: { bumpType: "patch", descriptions: ["Frontend change"] },
+      api: { bumpType: "minor", descriptions: ["API change"] }
+    };
+
+    syncReleaseGroup(aggregated, ["frontend", "api", "mmr-api"], bumpPriority);
+
+    assert.equal(aggregated.frontend.bumpType, "minor");
+    assert.equal(aggregated.api.bumpType, "minor");
+    assert.equal(aggregated["mmr-api"].bumpType, "minor");
+    assert.deepEqual(aggregated.frontend.descriptions, ["Frontend change"]);
+    assert.deepEqual(aggregated.api.descriptions, ["API change"]);
+    assert.deepEqual(aggregated["mmr-api"].descriptions, ["Sync release version with frontend and api."]);
+  });
+
+  it("does nothing when no grouped component changed", () => {
+    const aggregated = {
+      docs: { bumpType: "patch", descriptions: ["Docs change"] }
+    };
+
+    syncReleaseGroup(aggregated, ["frontend", "api", "mmr-api"], bumpPriority);
+
+    assert.deepEqual(aggregated, {
+      docs: { bumpType: "patch", descriptions: ["Docs change"] }
+    });
   });
 });
 

--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -15,6 +15,18 @@ export function syncCsprojVersion(projectPath, version) {
   fs.writeFileSync(projectPath, updatedProjectFile);
 }
 
+export function requireMatchingVersions(versions, componentNames) {
+  const selected = versions.filter(({ name }) => componentNames.includes(name));
+  const distinctVersions = new Set(selected.map(({ version }) => version));
+
+  if (distinctVersions.size === 1) {
+    return;
+  }
+
+  const details = selected.map(({ name, version }) => `- ${name}: ${version}`).join("\n");
+  throw new Error(`Release versions must match:\n${details}`);
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -39,6 +51,13 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   });
 
   const majors = new Set(versions.map(({ version }) => version.split(".")[0]));
+
+  try {
+    requireMatchingVersions(versions, ["frontend", "api", "mmr-api"]);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
 
   if (majors.size !== 1) {
     console.error("Release versions must share the same major:");

--- a/scripts/release/version.test.mjs
+++ b/scripts/release/version.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { syncCsprojVersion } from "./version.mjs";
+import { requireMatchingVersions, syncCsprojVersion } from "./version.mjs";
 
 describe("syncCsprojVersion", () => {
   let tmpDir;
@@ -81,5 +81,35 @@ describe("syncCsprojVersion", () => {
     const result = fs.readFileSync(csproj, "utf8");
     assert.match(result, /<Version>0\.2\.0<\/Version>/);
     assert.doesNotMatch(result, /0\.1\.0/);
+  });
+});
+
+describe("requireMatchingVersions", () => {
+  it("allows matching selected component versions", () => {
+    assert.doesNotThrow(() =>
+      requireMatchingVersions(
+        [
+          { name: "frontend", version: "1.2.0" },
+          { name: "api", version: "1.2.0" },
+          { name: "mmr-api", version: "1.2.0" }
+        ],
+        ["frontend", "api", "mmr-api"]
+      )
+    );
+  });
+
+  it("throws when selected component versions differ", () => {
+    assert.throws(
+      () =>
+        requireMatchingVersions(
+          [
+            { name: "frontend", version: "1.2.0" },
+            { name: "api", version: "1.2.0" },
+            { name: "mmr-api", version: "1.2.1" }
+          ],
+          ["frontend", "api", "mmr-api"]
+        ),
+      /Release versions must match/
+    );
   });
 });


### PR DESCRIPTION
Create a image for
- api
- mmr-api
- frontend

and releases them on github. Uses version from code, and follows semver from conventional commits

<img width="347" height="346" alt="Screenshot 2026-06-05 at 10 43 15" src="https://github.com/user-attachments/assets/18db3d5e-1793-48ec-a4c6-8035d69205d3" />

<img width="1093" height="598" alt="Screenshot 2026-06-05 at 10 43 26" src="https://github.com/user-attachments/assets/0a2f5aa3-2677-40b1-9fa3-ba9afaa1286d" />
