### PR TITLE
ci(api): pin .NET 10 SDK in test workflow

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Restore dependencies
         working-directory: ./api/MMRProject.Api
         run: dotnet restore


### PR DESCRIPTION
## What
Pin the .NET SDK to `10.0.x` in `.github/workflows/test-api.yml` (was `8.0.x`).

## Why
The API project targets `net10.0`, but the build/test workflow installed the .NET 8 SDK. It only passed because the `ubuntu-latest` runner image also happens to ship a .NET 10 SDK, so the explicit pin was a no-op. If the runner image drops .NET 10, or a `global.json` is added, the API build breaks with no code change. The `e2e.yml` workflow already pins `10.0.x`; this brings the test workflow in line.

## Testing
YAML-only. CI on this PR exercises it: the .NET build and integration-test suite now run against an explicitly pinned .NET 10 SDK.

## Release impact
CI-only change, no changeset (per AGENTS.md). Should be labeled `no-release`.