### PR TITLE
ci: publish container images to GHCR on release

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -48,8 +48,6 @@ jobs:
         with:
           appSourcePath: ${{ github.workspace }}/frontend
           acrName: ${{ secrets.ACR_NAME }}
-          buildArguments: |
-            "PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.CLERK_PUBLISHABLE_KEY }}"
           containerAppName: ${{ secrets.UI_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}
           targetPort: 3000

--- a/.github/workflows/publish-github-releases.yml
+++ b/.github/workflows/publish-github-releases.yml
@@ -51,6 +51,10 @@ jobs:
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
+      - name: Set up QEMU
+        if: steps.releases.outputs.released != '[]'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: steps.releases.outputs.released != '[]'
         uses: docker/setup-buildx-action@v3
@@ -69,8 +73,9 @@ jobs:
         with:
           context: ./frontend
           push: true
-          build-args: |
-            PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.CLERK_PUBLISHABLE_KEY }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
           tags: |
             ghcr.io/${{ steps.versions.outputs.repo }}/frontend:${{ steps.versions.outputs.frontend }}
             ghcr.io/${{ steps.versions.outputs.repo }}/frontend:latest
@@ -81,6 +86,9 @@ jobs:
         with:
           context: ./api/MMRProject.Api
           push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,mode=max,scope=api
           tags: |
             ghcr.io/${{ steps.versions.outputs.repo }}/api:${{ steps.versions.outputs.api }}
             ghcr.io/${{ steps.versions.outputs.repo }}/api:latest
@@ -91,6 +99,9 @@ jobs:
         with:
           context: ./mmr-api
           push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=mmr-api
+          cache-to: type=gha,mode=max,scope=mmr-api
           build-args: |
             VERSION=${{ steps.versions.outputs.mmr_api }}
           tags: |

--- a/.github/workflows/publish-github-releases.yml
+++ b/.github/workflows/publish-github-releases.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   publish:
@@ -26,9 +27,72 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Create GitHub releases
+        id: releases
         run: node ./scripts/release/create-releases.mjs "$BASE_SHA" "$HEAD_SHA"
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+
+      # Each released component is published as its own image tagged with its own
+      # version, mirroring the per-component GitHub releases created above. Only
+      # components whose version changed in this release are built.
+      - name: Read component versions
+        id: versions
+        if: steps.releases.outputs.released != '[]'
+        run: |
+          {
+            echo "frontend=$(node -p "require('./frontend/package.json').version")"
+            echo "api=$(node -p "require('./api/package.json').version")"
+            echo "mmr_api=$(node -p "require('./mmr-api/package.json').version")"
+            echo "repo=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Set up Docker Buildx
+        if: steps.releases.outputs.released != '[]'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: steps.releases.outputs.released != '[]'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend
+        if: contains(fromJson(steps.releases.outputs.released || '[]'), 'frontend')
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          build-args: |
+            PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.CLERK_PUBLISHABLE_KEY }}
+          tags: |
+            ghcr.io/${{ steps.versions.outputs.repo }}/frontend:${{ steps.versions.outputs.frontend }}
+            ghcr.io/${{ steps.versions.outputs.repo }}/frontend:latest
+
+      - name: Build and push api
+        if: contains(fromJson(steps.releases.outputs.released || '[]'), 'api')
+        uses: docker/build-push-action@v6
+        with:
+          context: ./api/MMRProject.Api
+          push: true
+          tags: |
+            ghcr.io/${{ steps.versions.outputs.repo }}/api:${{ steps.versions.outputs.api }}
+            ghcr.io/${{ steps.versions.outputs.repo }}/api:latest
+
+      - name: Build and push mmr-api
+        if: contains(fromJson(steps.releases.outputs.released || '[]'), 'mmr-api')
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mmr-api
+          push: true
+          build-args: |
+            VERSION=${{ steps.versions.outputs.mmr_api }}
+          tags: |
+            ghcr.io/${{ steps.versions.outputs.repo }}/mmr-api:${{ steps.versions.outputs.mmr_api }}
+            ghcr.io/${{ steps.versions.outputs.repo }}/mmr-api:latest

--- a/README.md
+++ b/README.md
@@ -96,6 +96,134 @@ The application uses Clerk for authentication. Follow these steps to get started
    npm run dev
    ```
 
+### Try Locally With Docker Compose
+
+Each release publishes container images for the frontend, API, and MMR API to
+the GitHub Container Registry under `ghcr.io/office-rivals/mmr-project`. You can
+run the whole stack from those prebuilt images without a local toolchain.
+
+Create a `.env` file next to the compose file with your Clerk values and local
+secrets:
+
+```bash
+PUBLIC_CLERK_PUBLISHABLE_KEY=<your_clerk_publishable_key>
+CLERK_SECRET_KEY=<your_clerk_secret_key>
+CLERK_ISSUER_URL=<your_clerk_issuer_url>
+POSTGRES_PASSWORD=local-postgres-password
+MMR_ADMIN_SECRET=local-admin-secret
+```
+
+Then create this compose file in the repository root. The images use `:latest`;
+pin a specific version tag (for example `:1.2.1`) if you need a fixed release.
+
+```yaml
+name: mmr-project-local
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: mmr_project
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d mmr_project"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mmr-api:
+    image: ghcr.io/office-rivals/mmr-project/mmr-api:latest
+    restart: unless-stopped
+    environment:
+      ADMIN_SECRET: ${MMR_ADMIN_SECRET}
+      MMR_API_PORT: 8080
+    ports:
+      - "8080:8080"
+
+  api:
+    image: ghcr.io/office-rivals/mmr-project/api:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mmr-api:
+        condition: service_started
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__ApiDbContext: Host=postgres;Port=5432;Database=mmr_project;Username=postgres;Password=${POSTGRES_PASSWORD}
+      Authorization__Issuer: ${CLERK_ISSUER_URL}
+      Migration__Enabled: "true"
+      MMRCalculationAPI__BaseUrl: http://mmr-api:8080
+      MMRCalculationAPI__ApiKey: ${MMR_ADMIN_SECRET}
+    ports:
+      - "8081:8080"
+
+  frontend:
+    image: ghcr.io/office-rivals/mmr-project/frontend:latest
+    restart: unless-stopped
+    depends_on:
+      - api
+    environment:
+      NODE_ENV: production
+      ORIGIN: http://localhost:3000
+      API_BASE_PATH: http://api:8080
+      PUBLIC_CLERK_PUBLISHABLE_KEY: ${PUBLIC_CLERK_PUBLISHABLE_KEY}
+      CLERK_SECRET_KEY: ${CLERK_SECRET_KEY}
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres-data:
+```
+
+Save it as `docker-compose.local.yml`, then start everything:
+
+```bash
+docker compose --env-file .env -f docker-compose.local.yml up
+```
+
+Open `http://localhost:3000`. The API is also available at `http://localhost:8081/swagger`.
+
+#### Create the first organization
+
+The deployed UI does not currently include a first-run organization creation
+screen. Create the first organization through the API after signing in locally.
+The authenticated user that creates the organization becomes its `Owner` and
+can then use the admin UI.
+
+1. Open `http://localhost:3000` and sign in with Clerk.
+2. Open your browser devtools console on the local frontend.
+3. Get a Clerk token:
+
+   ```js
+   await window.Clerk.session.getToken()
+   ```
+
+4. Use that token to create the organization through the local API:
+
+   ```bash
+   curl -X POST "http://localhost:8081/api/v3/organizations" \
+     -H "Authorization: Bearer <clerk_token_from_browser>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "Local Organization",
+       "slug": "local-org"
+     }'
+   ```
+
+5. Open `http://localhost:3000/admin`. The organization should be listed there.
+
+The `slug` becomes the organization URL segment, for example
+`http://localhost:3000/local-org`. Avoid reserved slugs such as `admin`,
+`api`, `login`, `join`, `profile`, `settings`, and `submit`.
+
 ## Development
 
 ### Frontend (SvelteKit)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,9 +4,6 @@ COPY package*.json ./
 RUN npm ci
 COPY . .
 
-ARG PUBLIC_CLERK_PUBLISHABLE_KEY
-
-ENV PUBLIC_CLERK_PUBLISHABLE_KEY=${PUBLIC_CLERK_PUBLISHABLE_KEY}
 RUN DEPLOY_TO_AZURE=true npm run build
 RUN npm prune --production
 

--- a/scripts/release/create-releases.mjs
+++ b/scripts/release/create-releases.mjs
@@ -37,6 +37,11 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
+  // Components whose version changed in this release. Collected independently of
+  // whether the GitHub release already exists, so a workflow re-run still reports
+  // them to downstream steps (e.g. image builds) after a transient failure.
+  const released = [];
+
   for (const component of components) {
     const currentPackage = readPackage(path.join(repoRoot, component.packageJsonPath));
     const previousPackage = readPackageFromGit(baseSha, component.packageJsonPath);
@@ -44,6 +49,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     if (previousPackage && previousPackage.version === currentPackage.version) {
       continue;
     }
+
+    released.push({ name: component.name, version: currentPackage.version });
 
     const tag = `${component.name}@${currentPackage.version}`;
     if (releaseExists(tag)) {
@@ -80,6 +87,11 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     } finally {
       fs.rmSync(notesDir, { recursive: true });
     }
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    const releasedNames = released.map(({ name }) => name);
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `released=${JSON.stringify(releasedNames)}\n`);
   }
 
   function readPackage(packageJsonPath) {


### PR DESCRIPTION
## What

Publishes multi-arch (`linux/amd64` + `linux/arm64`) container images for the **frontend**, **API**, and **MMR API** to the GitHub Container Registry (`ghcr.io/office-rivals/mmr-project/<component>`) on every release, and documents a `docker compose` quickstart that runs the whole stack from those prebuilt images.

The build runs inside the existing **Publish GitHub Releases** workflow, right after the GitHub releases are created. Each component is tagged with its own version plus `latest`, and only components whose version actually changed in the release are built (so a single-component release doesn't rebuild the others).

## Credit

This is a simplified take on the approach in #292 by @AndersSpringborg — the Docker build steps and the docker-compose quickstart are based on that PR. Thanks! 🙏 (Commit is co-authored accordingly.)

## How this differs from #292

- **Keeps independent per-component versioning.** #292 forced frontend/api/mmr-api to share a single version (via `syncReleaseGroup` + `requireMatchingVersions`) so all three images could carry one tag. This version preserves the current model — each image is tagged with its own component version, matching the existing `<component>@<version>` GitHub releases and the per-component **Deploy Release** workflow. No release-script version-locking is needed.
- **One workflow instead of two.** #292 added a separate `workflow_run`-triggered workflow, which checks out `workflow_run.head_sha` (the tip of `changeset-release/main`) rather than the merge commit the releases are tagged from. Folding the build into `publish-github-releases.yml` reuses the correct `merge_commit_sha` checkout and removes the extra moving part.
- **Correct image namespace.** Images publish under `ghcr.io/office-rivals/...` (derived from `GITHUB_REPOSITORY`), and the README references the same — instead of a personal fork namespace / hardcoded version.

## Implementation notes

- `create-releases.mjs` now emits a `released` output listing the components that got a version bump (based on the package.json diff, so a workflow **re-run after a transient build failure is still retry-safe**). The workflow uses it to decide which images to build.
- **Multi-arch builds.** Images are built for `linux/amd64` and `linux/arm64` (via `docker/setup-qemu-action`), so the docker-compose quickstart runs natively on Apple Silicon as well as on x86 servers.
- **Layer caching.** Each component build uses a per-component GitHub Actions cache (`type=gha`, scoped by component) to speed up release builds.
- **Clerk key is supplied at runtime, not baked in.** `svelte-clerk` reads `PUBLIC_CLERK_PUBLISHABLE_KEY` at runtime via `$env/dynamic/public`, and the Dockerfile's build-time `ENV` only ever existed in the builder stage (never the final image) — so the old build-arg never reached the running container. The frontend image is now built without it, and the now-dead `ARG`/`ENV` in `frontend/Dockerfile` plus the matching build-arg in **Deploy Release** are removed. The key is provided as a runtime env var: docker-compose locally, and the existing container-app env in Azure (confirmed already set). This also keeps the published image Clerk-instance-agnostic.
- Infra-only change → labeled `no-release`, no changeset. The first images publish on the next release that bumps a component.
- **GHCR package visibility.** Packages first pushed via `GITHUB_TOKEN` are private by default; each one needs to be set to public once after the first publish for the documented anonymous `docker compose` pull to work.

## Follow-up (not in this PR)

Migrate **Deploy Release** (`deploy-release.yml`) to pull these prebuilt GHCR images instead of rebuilding from source via `azure/container-apps-deploy-action`. That would make the release the single build step and turn deployment into an image pull, removing the duplicate Azure-side build.
