### PR TITLE
chore(deps-dev): remove unused postcss-load-config from frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,6 @@
         "eslint-plugin-svelte": "^3.19.0",
         "globals": "^17.6.0",
         "postcss": "^8.5.10",
-        "postcss-load-config": "^5.1.0",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^3.5.1",
         "prettier-plugin-tailwindcss": "^0.8.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,6 @@
     "eslint-plugin-svelte": "^3.19.0",
     "globals": "^17.6.0",
     "postcss": "^8.5.10",
-    "postcss-load-config": "^5.1.0",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^3.5.1",
     "prettier-plugin-tailwindcss": "^0.8.0",


### PR DESCRIPTION
## What

Removes the `postcss-load-config` direct devDependency from `frontend/package.json` (and its root entry in `package-lock.json`).

## Why

It's a leftover, unused direct devDependency:

- The only reference anywhere outside `node_modules`/lockfile was the `package.json` declaration itself — nothing in the repo imports or requires it.
- `frontend/postcss.config.cjs` loads `tailwindcss` and `autoprefixer` directly; it does not use `postcss-load-config`.
- It remains available transitively as a regular dependency of `tailwindcss@3.4.19` (range `^4.0.2 || ^5.0 || ^6.0`), and `eslint-plugin-svelte` carries its own separate nested copy. So removing the direct declaration does not remove it from the installed tree.

A side benefit: this stops Dependabot from opening bumps for a dependency we don't directly use (e.g. the pending major bump to v6).

## Verification

- `node_modules/postcss-load-config` is still resolved (`@5.1.0`, via `tailwindcss`) after the change.
- `npm run check` — 0 errors.
- `npm run build` — succeeds; the PostCSS/Tailwind pipeline runs as before.

## Release impact

None — removing an unused devDependency does not change the deployed artifact, so this carries the `no-release` label and intentionally omits a changeset.