### PR TITLE
chore(mmr-api): patch version bump

### DIFF
--- a/.changeset/mmr-api-patch-bump.md
+++ b/.changeset/mmr-api-patch-bump.md
@@ -1,0 +1,5 @@
+---
+"mmr-api": patch
+---
+
+Patch version bump for mmr-api.


### PR DESCRIPTION
## Summary

Changeset-only PR that declares a **patch** bump for the **mmr-api** component. There are **no functional code changes** — this PR exists purely to trigger a patch release of mmr-api via the release PR workflow.

## Changes

- Add `.changeset/mmr-api-patch-bump.md` declaring `"mmr-api": patch`.

## Notes

- Per `AGENTS.md`, version fields and `CHANGELOG.md` files are owned by the release PR workflow (`scripts/release/apply-changesets.mjs`) and are intentionally **not** edited here.
- This PR should **not** get the `no-release` label — it is intended to produce a release.