### PR TITLE
fix(mmr-api): timing-safe admin key comparison

### DIFF
--- a/.changeset/timing-safe-mmr-api-auth.md
+++ b/.changeset/timing-safe-mmr-api-auth.md
@@ -1,0 +1,5 @@
+---
+"mmr-api": patch
+---
+
+Use `crypto/subtle.ConstantTimeCompare` for admin key validation to prevent timing-based key enumeration, and explicitly reject an empty `ADMIN_SECRET` to make the fail-closed property clear.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ ADMIN_SECRET=<admin_secret>
 ## Testing
 
 - **API**: Bruno collection in `api-collection/` for API testing
-- **MMR API**: Go tests in `mmr-api/test/` organized by package (api, custom, mmr, openskill)
+- **MMR API**: Go tests in `mmr-api/test/` organized by package (api, custom, middleware, mmr, openskill)
 - **Frontend**: Component testing with Vitest (configured but not extensively used)
 
 ## Deployment

--- a/mmr-api/middleware/auth.go
+++ b/mmr-api/middleware/auth.go
@@ -1,15 +1,19 @@
 package middleware
 
 import (
-	"github.com/gin-gonic/gin"
+	"crypto/subtle"
 	"net/http"
 	"os"
+
+	"github.com/gin-gonic/gin"
 )
 
 func RequireAdminAuth(c *gin.Context) {
 	apiKey := c.GetHeader("X-API-KEY")
+	secret := os.Getenv("ADMIN_SECRET")
 
-	if apiKey == "" || apiKey != os.Getenv("ADMIN_SECRET") {
+	if apiKey == "" || secret == "" ||
+		subtle.ConstantTimeCompare([]byte(apiKey), []byte(secret)) != 1 {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return
 	}

--- a/mmr-api/test/middleware/auth_test.go
+++ b/mmr-api/test/middleware/auth_test.go
@@ -1,0 +1,79 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"mmr/backend/middleware"
+)
+
+func setupAuthRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/protected", middleware.RequireAdminAuth, func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	return r
+}
+
+func TestRequireAdminAuth_CorrectKey(t *testing.T) {
+	t.Setenv("ADMIN_SECRET", "correct-secret")
+	r := setupAuthRouter()
+
+	req, _ := http.NewRequest("GET", "/protected", nil)
+	req.Header.Set("X-API-KEY", "correct-secret")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestRequireAdminAuth_WrongKey(t *testing.T) {
+	t.Setenv("ADMIN_SECRET", "correct-secret")
+	r := setupAuthRouter()
+
+	req, _ := http.NewRequest("GET", "/protected", nil)
+	req.Header.Set("X-API-KEY", "wrong-secret")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestRequireAdminAuth_EmptyHeader(t *testing.T) {
+	t.Setenv("ADMIN_SECRET", "correct-secret")
+	r := setupAuthRouter()
+
+	req, _ := http.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestRequireAdminAuth_EmptySecretAndEmptyHeader(t *testing.T) {
+	t.Setenv("ADMIN_SECRET", "")
+	r := setupAuthRouter()
+
+	req, _ := http.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestRequireAdminAuth_EmptySecretNonEmptyHeader(t *testing.T) {
+	t.Setenv("ADMIN_SECRET", "")
+	r := setupAuthRouter()
+
+	req, _ := http.NewRequest("GET", "/protected", nil)
+	req.Header.Set("X-API-KEY", "some-key")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}


### PR DESCRIPTION
Closes #307.

## What

Hardens the MMR API admin-auth gate (`RequireAdminAuth`) against timing-based key enumeration.

- Replaces the short-circuiting `apiKey != os.Getenv("ADMIN_SECRET")` byte comparison with `crypto/subtle.ConstantTimeCompare`.
- Adds an explicit empty-`ADMIN_SECRET` guard so the fail-closed property is obvious (behavior is unchanged — an unset secret already rejected every request).

## Why

A byte-wise `!=` compare short-circuits on the first mismatching byte, leaking via timing how many leading bytes of a guess are correct. Remote exploitation is largely theoretical, but the fix is one line and removes the finding class on an auth gate. See #307 for the full rationale.

## Behavior

The accept condition is provably identical to before (`apiKey != "" && apiKey == secret`), now evaluated in constant time. No API or signature changes.

## Tests

Adds the package's first middleware suite, `mmr-api/test/middleware/auth_test.go` (5 cases):

- correct key → 200 (next handler runs)
- wrong key → 401
- empty header → 401
- empty secret + empty header → 401
- empty secret + non-empty header → 401 (the key regression guard)

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Notes

- `crypto/subtle.ConstantTimeCompare` is constant-time only for equal-length inputs (length still leaks via timing) — the standard, accepted trade-off for this primitive; not worth a digest-compare for an admin secret.
- Reading `ADMIN_SECRET` once at startup was intentionally left out of scope.
- Includes a `mmr-api: patch` changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key validation security by implementing constant-time comparison to prevent timing-based enumeration attacks.
  * Enhanced security posture by explicitly rejecting invalid or empty authentication configurations with a fail-closed approach.

* **Tests**
  * Added comprehensive test coverage for API key validation including correct keys, wrong keys, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->