### PR TITLE
ci(frontend): run lint on PRs and fix pre-existing prettier drift

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -49,6 +49,10 @@ jobs:
         if: steps.frontend_changes.outputs.has_changes == 'true'
         run: npm ci
         working-directory: ./frontend
+      - name: Lint
+        if: steps.frontend_changes.outputs.has_changes == 'true'
+        run: npm run lint
+        working-directory: ./frontend
       - name: Unit Test
         if: steps.frontend_changes.outputs.has_changes == 'true'
         run: npm run test

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -2,3 +2,8 @@
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Release tooling (scripts/release/apply-changesets.mjs) owns this file and writes
+# entries without a prettier pass; policing it here would red the auto-generated
+# release PR. Keep it out of the formatter.
+CHANGELOG.md

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -40,12 +40,12 @@ The e2e stack is fully isolated from local development. You can have
 your dev stack running and start `npm run e2e` without anything
 colliding.
 
-| Service     | Local dev | e2e   | Override env var      |
-| ----------- | --------- | ----- | --------------------- |
-| Postgres    | 5432      | 5433  | `E2E_DB_PORT`         |
-| mmr-api     | 8080      | 8090  | `E2E_MMR_API_PORT`    |
-| .NET API    | 8081      | 8091  | `E2E_API_PORT`        |
-| Vite dev    | 5173      | 5180  | `E2E_PORT`            |
+| Service  | Local dev | e2e  | Override env var   |
+| -------- | --------- | ---- | ------------------ |
+| Postgres | 5432      | 5433 | `E2E_DB_PORT`      |
+| mmr-api  | 8080      | 8090 | `E2E_MMR_API_PORT` |
+| .NET API | 8081      | 8091 | `E2E_API_PORT`     |
+| Vite dev | 5173      | 5180 | `E2E_PORT`         |
 
 The e2e Postgres data lives in a named docker volume (`mmr-e2e-db`) so
 EF migrations only run on first boot. To wipe the e2e DB completely:

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -25,7 +25,8 @@ const E2E_FRONTEND_PORT = process.env.E2E_PORT ?? '5180';
 
 const MMR_API_URL = `http://localhost:${E2E_MMR_API_PORT}`;
 const API_URL = `http://localhost:${E2E_API_PORT}`;
-const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${E2E_FRONTEND_PORT}`;
+const BASE_URL =
+  process.env.E2E_BASE_URL ?? `http://localhost:${E2E_FRONTEND_PORT}`;
 
 const API_CONNECTION_STRING =
   `Host=${E2E_DB_HOST};Port=${E2E_DB_PORT};` +

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/matchmaking/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/matchmaking/+page.svelte
@@ -112,12 +112,12 @@
 
 <div class="mt-6 flex flex-col gap-4">
   <p>
-    Matchmaking is a feature where you queue up for a {formatLabel} game against
-    other people that are also ready for a game.
+    Matchmaking is a feature where you queue up for a {formatLabel} game against other
+    people that are also ready for a game.
   </p>
   <p>
-    Once <strong>{playersRequiredForMatch} players</strong> are in the queue, a
-    match will be created and you will be notified.
+    Once <strong>{playersRequiredForMatch} players</strong> are in the queue, a match
+    will be created and you will be notified.
   </p>
   <p>
     If you do not accept the match within <strong>30 seconds</strong>, you will

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.svelte
@@ -107,11 +107,7 @@
                   Edit
                 </Button>
                 <form method="POST" action="?/recalculate" use:enhance>
-                  <input
-                    type="hidden"
-                    name="fromMatchId"
-                    value={match.id}
-                  />
+                  <input type="hidden" name="fromMatchId" value={match.id} />
                   <Button
                     type="submit"
                     size="sm"

--- a/frontend/src/routes/admin/[orgSlug]/members/+page.server.ts
+++ b/frontend/src/routes/admin/[orgSlug]/members/+page.server.ts
@@ -21,10 +21,10 @@ export const actions: Actions = {
     const formData = await request.formData();
     const email = formData.get('email') as string;
     const role = formData.get('role') as string;
-    const displayName =
-      ((formData.get('displayName') as string | null) ?? '').trim();
-    const username =
-      ((formData.get('username') as string | null) ?? '').trim();
+    const displayName = (
+      (formData.get('displayName') as string | null) ?? ''
+    ).trim();
+    const username = ((formData.get('username') as string | null) ?? '').trim();
 
     const orgId = await resolveOrgIdBySlug(apiClientV3, params.orgSlug);
     if (!orgId) return fail(404, { error: 'Organization not found' });


### PR DESCRIPTION
Closes #310.

## What & why

The frontend defines a lint gate — `npm run lint` = `prettier --check . && eslint .` — but **no CI workflow ran it** (zero `lint`/`prettier`/`eslint` references across `.github/workflows/`). With nothing enforcing it, `main` drifted: `npm run lint` exited non-zero because 6 files failed `prettier --check`. This PR makes frontend PRs run `npm run lint`, after first getting lint back to green.

eslint itself was already clean (0 errors, 53 pre-existing `warn`-level findings that don't fail the gate), so the only blocker was prettier formatting.

## Changes

- **`.github/workflows/test-ui.yml`** — new **Lint** step (`npm run lint`), gated on frontend changes, alongside the existing Unit Test step.
- **`frontend/.prettierignore`** — add `CHANGELOG.md` (see below).
- **Formatting-only reflows** (no logic/content change): `frontend/e2e/README.md`, `frontend/playwright.config.ts`, and 3 route files (`matchmaking/+page.svelte`, admin `matches/+page.svelte`, admin `members/+page.server.ts`).

## Why `CHANGELOG.md` is ignored, not formatted

`frontend/CHANGELOG.md` is generated by the release tooling (`scripts/release/apply-changesets.mjs` → `updateChangelog`), which appends entries verbatim with no prettier pass. Release PRs touch `frontend/**`, so a CHANGELOG-inclusive prettier gate would red the auto-generated release PR on every release. Excluding it keeps the gate stable. (Considered and rejected: teaching the release script to emit prettier-clean output — scope creep into release tooling.)

## Verification

- `npm run lint` → exit 0 (`prettier --check .` clean; `eslint .` 0 errors, 53 warnings)
- `npm run check` → 0 errors
- `git diff frontend/CHANGELOG.md` → empty (changelog untouched)

## Release

CI/infra only → no changeset; `no-release` label applied per AGENTS.md.

## Follow-up (not in this PR)

The 53 eslint warnings (`svelte/require-each-key`, `svelte/no-navigation-without-resolve`) remain unenforced. Gating them (`--max-warnings 0`) needs clearing them first — a separate change.