### PR TITLE
ci(deploy): deploy released GHCR images instead of building from source

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -12,7 +12,7 @@ on:
           - api
           - mmr-api
       version:
-        description: Released version to deploy
+        description: Released version to deploy (bare semver, e.g. 1.2.3)
         required: true
         type: string
 
@@ -26,22 +26,37 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      # Single source of truth for the GHCR image path. Mirrors the lowercase
+      # owner/repo that publish-github-releases.yml pushes to.
+      IMAGE_BASE: ghcr.io/office-rivals/mmr-project
     steps:
+      # Accept a v-prefixed or whitespace-padded version and reduce it to the
+      # bare semver that the release tag and GHCR image tag actually use.
+      - name: Normalize version
+        id: ver
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="${RAW_VERSION//[[:space:]]/}"
+          version="${version#[vV]}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Verify release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
+          RELEASE_TAG: ${{ format('{0}@{1}', inputs.component, steps.ver.outputs.version) }}
         run: gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
 
       # Deploy the image already built and pushed by publish-github-releases.yml,
-      # which tags ghcr.io/<owner>/<repo>/<component> with the component's bare
-      # semver. The owner/repo segment is lowercase to match that workflow. These
+      # which tags $IMAGE_BASE/<component> with the component's bare semver. These
       # GHCR packages are public, so Azure Container Apps pulls them directly with
       # no registry credentials (no packages: read permission required here).
       - name: Verify GHCR image exists
         env:
-          IMAGE: ghcr.io/office-rivals/mmr-project/${{ inputs.component }}:${{ inputs.version }}
-        run: docker buildx imagetools inspect "$IMAGE" >/dev/null
+          COMPONENT: ${{ inputs.component }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: docker buildx imagetools inspect "${IMAGE_BASE}/${COMPONENT}:${VERSION}" >/dev/null
 
       - name: Log in to Azure
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
@@ -50,25 +65,25 @@ jobs:
 
       - name: Deploy frontend release
         if: inputs.component == 'frontend'
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
-          imageToDeploy: ghcr.io/office-rivals/mmr-project/frontend:${{ inputs.version }}
+          imageToDeploy: ${{ env.IMAGE_BASE }}/frontend:${{ steps.ver.outputs.version }}
           containerAppName: ${{ secrets.UI_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}
           targetPort: 3000
 
       - name: Deploy api release
         if: inputs.component == 'api'
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
-          imageToDeploy: ghcr.io/office-rivals/mmr-project/api:${{ inputs.version }}
+          imageToDeploy: ${{ env.IMAGE_BASE }}/api:${{ steps.ver.outputs.version }}
           containerAppName: ${{ secrets.API_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}
 
       - name: Deploy mmr-api release
         if: inputs.component == 'mmr-api'
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
-          imageToDeploy: ghcr.io/office-rivals/mmr-project/mmr-api:${{ inputs.version }}
+          imageToDeploy: ${{ env.IMAGE_BASE }}/mmr-api:${{ steps.ver.outputs.version }}
           containerAppName: ${{ secrets.MMR_API_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -33,9 +33,15 @@ jobs:
           RELEASE_TAG: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
         run: gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
 
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
+      # Deploy the image already built and pushed by publish-github-releases.yml,
+      # which tags ghcr.io/<owner>/<repo>/<component> with the component's bare
+      # semver. The owner/repo segment is lowercase to match that workflow. These
+      # GHCR packages are public, so Azure Container Apps pulls them directly with
+      # no registry credentials (no packages: read permission required here).
+      - name: Verify GHCR image exists
+        env:
+          IMAGE: ghcr.io/office-rivals/mmr-project/${{ inputs.component }}:${{ inputs.version }}
+        run: docker buildx imagetools inspect "$IMAGE" >/dev/null
 
       - name: Log in to Azure
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
@@ -46,8 +52,7 @@ jobs:
         if: inputs.component == 'frontend'
         uses: azure/container-apps-deploy-action@v2
         with:
-          appSourcePath: ${{ github.workspace }}/frontend
-          acrName: ${{ secrets.ACR_NAME }}
+          imageToDeploy: ghcr.io/office-rivals/mmr-project/frontend:${{ inputs.version }}
           containerAppName: ${{ secrets.UI_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}
           targetPort: 3000
@@ -56,8 +61,7 @@ jobs:
         if: inputs.component == 'api'
         uses: azure/container-apps-deploy-action@v2
         with:
-          appSourcePath: ${{ github.workspace }}/api/MMRProject.Api
-          acrName: ${{ secrets.ACR_NAME }}
+          imageToDeploy: ghcr.io/office-rivals/mmr-project/api:${{ inputs.version }}
           containerAppName: ${{ secrets.API_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}
 
@@ -65,9 +69,6 @@ jobs:
         if: inputs.component == 'mmr-api'
         uses: azure/container-apps-deploy-action@v2
         with:
-          appSourcePath: ${{ github.workspace }}/mmr-api
-          acrName: ${{ secrets.ACR_NAME }}
-          buildArguments: |
-            VERSION=${{ inputs.version }}
+          imageToDeploy: ghcr.io/office-rivals/mmr-project/mmr-api:${{ inputs.version }}
           containerAppName: ${{ secrets.MMR_API_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.RESOURCE_GROUP }}


### PR DESCRIPTION
## What

Switch the **Deploy Release** workflow (`.github/workflows/deploy-release.yml`) from **building each component from source into ACR** to **deploying the pre-built, already-released container images from GHCR**.

For each component the `azure/container-apps-deploy-action@v2` step now uses:

```yaml
imageToDeploy: ghcr.io/office-rivals/mmr-project/<component>:${{ inputs.version }}
```

instead of `appSourcePath` + `acrName` (+ `buildArguments` for mmr-api).

## Why

`publish-github-releases.yml` already builds & pushes multi-arch images on every release to:

- `ghcr.io/office-rivals/mmr-project/frontend:<version>` (+ `:latest`)
- `ghcr.io/office-rivals/mmr-project/api:<version>` (+ `:latest`)
- `ghcr.io/office-rivals/mmr-project/mmr-api:<version>` (+ `:latest`)

`<version>` is the bare semver from each component's `package.json`; the owner/repo path is lowercase. Deploying these images directly removes a redundant per-deploy build, makes deploys faster, and guarantees the deployed artifact is byte-identical to what was released and tested.

## Notes / decisions

- **Depends on the GHCR packages being public.** Azure Container Apps pulls the images directly, so no registry credentials are needed. (If a package were made private, `registryUrl`/`registryUsername`/`registryPassword` would have to be supplied to the action.)
- **mmr-api version is preserved.** The published mmr-api image bakes the version in at publish time (`build-args: VERSION=<v>` → `-ldflags "-X main.version=${VERSION}"`), so dropping the deploy-time build does **not** lose `main.version`. The `buildArguments: VERSION=…` is removed.
- **Action vs. `az containerapp update`:** kept `azure/container-apps-deploy-action@v2`. Its `imageToDeploy` input — _"The custom name of an image that has already been pushed to the Container Registry"_ — cleanly deploys an existing external image, and per the action docs registry auth inputs are only required when the image needs authentication (not the case for our public GHCR images). No fallback to `az containerapp update` needed.
- **Permissions:** unchanged — still `contents: read` only (needed for the `gh release view` check). `packages: read` is **not** added: Azure pulls the public image, and the runner's GHCR manifest check is an anonymous public-registry read, so the `GITHUB_TOKEN` package scope is unused.
- **Checkout removed:** no source is built any more, so `actions/checkout` is dropped. The "Verify release exists" step is kept, and a fast `docker buildx imagetools inspect` step verifies the GHCR tag exists before the Azure deploy so we fail early if a published image is missing.
- `ACR_NAME` secret is no longer referenced by this workflow (left in place; harmless).

## Validation

- `actionlint` v1.7.12: clean (exit 0).
- YAML parses; `workflow_dispatch` inputs, `concurrency`, naming, and structure intact.

## Release impact

CI/infra-only change to a single workflow file — **no changeset**, labeled `no-release`. Must not trigger a release.

---

## Follow-up hardening (review cleanup)

A self-review surfaced three low-severity items, now addressed (the only correctness candidates — the action's GHCR invalid-secret-name behavior and spurious-environment creation — were verified against the action source as **not applicable** to a credential-less public image deployed to an already-existing app):

- **SHA-pin the deploy action.** `azure/container-apps-deploy-action@v2` is now pinned to commit `8dff69dac3367c32ceb2690d8f13adbeab462703` (the current `v2`), matching the already-SHA-pinned `azure/login` step, for reproducible deploys. (Upstream `v2` still runs on the deprecated node16 runtime and there is no node20 release yet, so the pin is the most we can do here.)
- **DRY the image path.** The `ghcr.io/office-rivals/mmr-project` prefix now lives in a single job-level `IMAGE_BASE` env instead of being duplicated across the verify + three deploy steps.
- **Normalize the `version` input.** A leading `v`/`V` and surrounding whitespace are stripped to the bare semver used by both the release tag and the GHCR image tag, so a `v1.2.3`-style entry no longer hard-fails the verify gates.

**Accepted as-is:** the workflow depends on the GHCR packages staying public (no `packages: read`, no registry credentials). Verified public today; treated as an explicit operational precondition rather than guarded with a login.
