### PR TITLE
fix(frontend): null-guard current-season UI + reuse selectCurrentSeason (follow-up to #323)

### DIFF
--- a/.changeset/season-ui-followups.md
+++ b/.changeset/season-ui-followups.md
@@ -1,0 +1,8 @@
+---
+"frontend": patch
+---
+
+Hide the "Report match" affordance on a league with no active season (e.g. a
+league whose only seasons are not yet started), and reuse the shared
+`selectCurrentSeason` helper in the admin seasons page so current-season
+selection has a single, order-independent definition.

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.server.ts
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.server.ts
@@ -16,7 +16,8 @@ export const load: PageServerLoad = async ({
     const currentSeason = selectCurrentSeason(seasons);
     const seasonId = urlSeasonId ?? currentSeason?.id;
     const isCurrentSeason =
-      urlSeasonId == null || urlSeasonId === currentSeason?.id;
+      currentSeason != null &&
+      (urlSeasonId == null || urlSeasonId === currentSeason.id);
 
     const ratingHistoryPromise = apiClientV3.ratingHistoryApi
       .getLeagueHistory(orgId, leagueId, seasonId)

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/seasons/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/seasons/+page.svelte
@@ -14,6 +14,7 @@
   import { Label } from '$lib/components/ui/label';
   import { CalendarDays, Plus } from 'lucide-svelte';
   import { formatDateTime } from '$lib/utils';
+  import { selectCurrentSeason } from '$lib/util/season';
   import type { ActionData, PageData } from './$types';
 
   let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -26,10 +27,8 @@
     )
   );
 
-  // The current season is the most recent one whose startsAt is in the past.
   const currentSeasonId = $derived(
-    sortedSeasons.find((s) => new Date(s.startsAt).getTime() <= Date.now())
-      ?.id ?? null
+    selectCurrentSeason(data.seasons)?.id ?? null
   );
 </script>
 


### PR DESCRIPTION
Follow-up polish to #323 (merged), applying the two low-severity findings from
the `/code-review max` pass on that PR.

## F1 — null-guard the current-season UI
`(authed)/[orgSlug]/[leagueSlug]/+page.server.ts`: `isCurrentSeason` no longer
treats "no `?season=` param" as the current season when there is **no** active
season. #323 made `currentSeason === null` reachable for a member in a league
whose only seasons are not yet started; this hides the "Report match" affordance
in that case instead of showing it with an `undefined` season id.

```ts
const isCurrentSeason =
  currentSeason != null && (urlSeasonId == null || urlSeasonId === currentSeason.id);
```

## F2 — reuse the shared `selectCurrentSeason` helper
`admin/[orgSlug]/leagues/[leagueSlug]/seasons/+page.svelte`: replaced the
hand-rolled current-season derivation with `selectCurrentSeason` (introduced in
#323), so there's a single, order-independent, NaN-safe definition. `sortedSeasons`
and the "Scheduled" badge logic are unchanged.

## Verification
- `npm run check` 0 errors, `npm run lint` 0 errors, `vitest` 27/27 (verified on a
  clean checkout).

Pure frontend polish; no behavior change beyond hiding an affordance that had
nothing to act on. Changeset: `frontend: patch`.
