### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read in test workflows

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -15,6 +15,9 @@ on:
       - "api/**/*"
       - ".github/workflows/test-api.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-mmr-api.yml
+++ b/.github/workflows/test-mmr-api.yml
@@ -15,6 +15,9 @@ on:
       - "mmr-api/**/*"
       - ".github/workflows/test-mmr-api.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -12,6 +12,9 @@ on:
       - "frontend/**/*"
       - ".github/workflows/test-ui.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds an explicit `permissions: { contents: read }` block to the three CI test workflows that previously declared none:

- `.github/workflows/test-ui.yml`
- `.github/workflows/test-mmr-api.yml`
- `.github/workflows/test-api.yml`

## Why

CodeQL code scanning flagged all three with `actions/missing-workflow-permissions` (medium). With no `permissions` block, `GITHUB_TOKEN` falls back to the repository default, which can grant broad write scope. These are read-only CI jobs (checkout → build → test, plus a Codecov upload that authenticates with its own `CODECOV_TOKEN`), so least privilege is `contents: read`.

This matches the convention already used in `e2e.yml` and `deploy-release.yml`.

## Notes

- CI-only change touching no deployed component → `no-release`, no changeset.
- Resolves the 3 open `actions/missing-workflow-permissions` code scanning alerts once re-scanned.