### PR TITLE
feat(frontend): group recent matches and player history by date

### DIFF
--- a/.changeset/frontend-date-utils-refactor.md
+++ b/.changeset/frontend-date-utils-refactor.md
@@ -1,0 +1,12 @@
+---
+"frontend": patch
+---
+
+Refactor date helpers in `src/lib/utils.ts` to remove duplication:
+collapse the repeated null/empty/NaN guards behind a private
+`parseLocalDate` helper, replace three local `formatDate`
+redefinitions in `admin/members`, `admin/.../match-flags` and
+`settings` with the shared one, and simplify the date-bucket boundary
+check in `groupMatchesByDate`. Behaviour is unchanged except that the
+admin match-flags page now formats dates in the user's locale instead
+of forcing `en-US`.

--- a/.changeset/frontend-recent-matches-date-groups.md
+++ b/.changeset/frontend-recent-matches-date-groups.md
@@ -1,0 +1,9 @@
+---
+"frontend": patch
+---
+
+Group matches in the recent-matches list on the league page and the match
+history on the player page by date. A small uppercase header ("Yesterday" or
+"Wednesday, Mar 5") appears above each new date bucket when the previous match
+was either from today or from a different day, so users can scan older matches
+without comparing per-row timestamps.

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  groupMatchesByDate,
+  isToday,
+  matchDateGroupKey,
+  matchDateGroupLabel,
+} from './utils';
+
+// Anchor "now" to a fixed local instant so date math is deterministic.
+// Picked at midday to avoid any DST edge cases.
+const NOW = new Date(2026, 5, 15, 12, 0, 0).getTime(); // 2026-06-15 12:00 local
+
+const iso = (d: Date) => d.toISOString();
+const at = (year: number, month: number, day: number, hour = 12) =>
+  iso(new Date(year, month - 1, day, hour, 0, 0));
+
+describe('isToday', () => {
+  it('returns true for a timestamp on the same local day as now', () => {
+    expect(isToday(at(2026, 6, 15, 9), NOW)).toBe(true);
+    expect(isToday(at(2026, 6, 15, 23), NOW)).toBe(true);
+  });
+
+  it('returns false for yesterday / tomorrow / older dates', () => {
+    expect(isToday(at(2026, 6, 14), NOW)).toBe(false);
+    expect(isToday(at(2026, 6, 16), NOW)).toBe(false);
+    expect(isToday(at(2025, 6, 15), NOW)).toBe(false);
+  });
+
+  it('returns false for null / undefined / empty / unparseable input', () => {
+    expect(isToday(null, NOW)).toBe(false);
+    expect(isToday(undefined, NOW)).toBe(false);
+    expect(isToday('', NOW)).toBe(false);
+    expect(isToday('not-a-date', NOW)).toBe(false);
+  });
+});
+
+describe('matchDateGroupKey', () => {
+  it("returns 'today' / 'yesterday' for those relative days", () => {
+    expect(matchDateGroupKey(at(2026, 6, 15), NOW)).toBe('today');
+    expect(matchDateGroupKey(at(2026, 6, 14), NOW)).toBe('yesterday');
+  });
+
+  it('returns a stable YYYY-MM-DD key for older dates', () => {
+    expect(matchDateGroupKey(at(2025, 3, 5), NOW)).toBe('2025-03-05');
+  });
+
+  it('distinguishes the same weekday/month/day in different years', () => {
+    // Both display as "Wednesday, Mar 5" with no year.
+    expect(matchDateGroupKey(at(2025, 3, 5), NOW)).not.toBe(
+      matchDateGroupKey(at(2026, 3, 5), NOW)
+    );
+  });
+
+  it('returns "" for null / undefined / empty / unparseable input', () => {
+    expect(matchDateGroupKey(null, NOW)).toBe('');
+    expect(matchDateGroupKey(undefined, NOW)).toBe('');
+    expect(matchDateGroupKey('', NOW)).toBe('');
+    expect(matchDateGroupKey('not-a-date', NOW)).toBe('');
+  });
+});
+
+describe('matchDateGroupLabel', () => {
+  it('returns "" for null / undefined / empty / unparseable input', () => {
+    expect(matchDateGroupLabel(null, NOW)).toBe('');
+    expect(matchDateGroupLabel(undefined, NOW)).toBe('');
+    expect(matchDateGroupLabel('', NOW)).toBe('');
+    expect(matchDateGroupLabel('not-a-date', NOW)).toBe('');
+  });
+
+  it('returns "Yesterday" for yesterday regardless of time of day', () => {
+    expect(matchDateGroupLabel(at(2026, 6, 14, 0), NOW)).toBe('Yesterday');
+    expect(matchDateGroupLabel(at(2026, 6, 14, 23), NOW)).toBe('Yesterday');
+  });
+
+  it('returns a weekday, month day string for older dates', () => {
+    const label = matchDateGroupLabel(at(2026, 3, 5), NOW);
+    expect(label).toBe('Thursday, Mar 5');
+  });
+});
+
+describe('groupMatchesByDate', () => {
+  const mk = (id: string, playedAt: string) => ({ id, playedAt });
+
+  it('returns an empty array for no matches', () => {
+    expect(groupMatchesByDate([], NOW)).toEqual([]);
+  });
+
+  it('labels only the first match of each non-today bucket', () => {
+    const matches = [
+      mk('m1', at(2026, 6, 15)), // today
+      mk('m2', at(2026, 6, 15)),
+      mk('m3', at(2026, 6, 14)), // yesterday — new bucket
+      mk('m4', at(2026, 6, 14)),
+      mk('m5', at(2026, 6, 12)), // older day — new bucket
+      mk('m6', at(2026, 6, 12)),
+    ];
+    expect(groupMatchesByDate(matches, NOW)).toEqual([
+      { match: matches[0], label: null },
+      { match: matches[1], label: null },
+      { match: matches[2], label: 'Yesterday' },
+      { match: matches[3], label: null },
+      { match: matches[4], label: 'Friday, Jun 12' },
+      { match: matches[5], label: null },
+    ]);
+  });
+
+  it('starts a new bucket for the very first match when it is not today', () => {
+    const matches = [mk('m1', at(2026, 6, 13)), mk('m2', at(2026, 6, 13))];
+    expect(groupMatchesByDate(matches, NOW)).toEqual([
+      { match: matches[0], label: 'Saturday, Jun 13' },
+      { match: matches[1], label: null },
+    ]);
+  });
+
+  it('does not label a single today-only list', () => {
+    const matches = [mk('m1', at(2026, 6, 15)), mk('m2', at(2026, 6, 15))];
+    expect(groupMatchesByDate(matches, NOW)).toEqual([
+      { match: matches[0], label: null },
+      { match: matches[1], label: null },
+    ]);
+  });
+
+  it('does not collapse two matches with colliding display labels across years', () => {
+    // Both render as "Wednesday, Mar 5" with the legacy day-comparison
+    // approach but live on different days in different years — each is its
+    // own bucket.
+    const matches = [
+      mk('m1', at(2026, 6, 15)), // today
+      mk('m2', at(2026, 3, 5)),
+      mk('m3', at(2025, 3, 5)),
+      mk('m4', at(2025, 3, 4)),
+    ];
+    const result = groupMatchesByDate(matches, NOW);
+    expect(result[0].label).toBeNull();
+    expect(result[1].label).not.toBeNull();
+    expect(result[2].label).not.toBeNull();
+    expect(result[1].label).not.toBe(result[2].label);
+    expect(result[3].label).not.toBeNull();
+    expect(result[2].label).not.toBe(result[3].label);
+  });
+});

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -7,38 +7,107 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatDate(d: string | null | undefined): string {
-  if (!d) return '—';
-  return new Date(d).toLocaleDateString();
+function parseLocalDate(d: string | null | undefined): Date | null {
+  if (!d) return null;
+  const date = new Date(d);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatDate(
+  d: string | null | undefined,
+  fallback = '—',
+  localeOptions?: Intl.DateTimeFormatOptions
+): string {
+  const date = parseLocalDate(d);
+  if (!date) return fallback;
+  return localeOptions
+    ? date.toLocaleDateString(undefined, localeOptions)
+    : date.toLocaleDateString();
 }
 
 export function formatDateTime(d: string | null | undefined): string {
-  if (!d) return '—';
-  return new Date(d).toLocaleString();
+  const date = parseLocalDate(d);
+  return date ? date.toLocaleString() : '—';
 }
 
-export function isToday(d: string | null | undefined): boolean {
-  if (!d) return false;
-  const date = new Date(d);
-  const now = new Date();
-  return (
-    date.getFullYear() === now.getFullYear() &&
-    date.getMonth() === now.getMonth() &&
-    date.getDate() === now.getDate()
-  );
+const isSameDay = (d1: Date, d2: Date): boolean =>
+  d1.getFullYear() === d2.getFullYear() &&
+  d1.getMonth() === d2.getMonth() &&
+  d1.getDate() === d2.getDate();
+
+/**
+ * True when `d` falls on the same local calendar day as `now`.
+ * `now` defaults to `Date.now()` and can be pinned (e.g. from PageData)
+ * to avoid SSR/client hydration mismatches around midnight.
+ */
+export function isToday(
+  d: string | null | undefined,
+  now: number = Date.now()
+): boolean {
+  const date = parseLocalDate(d);
+  return !!date && isSameDay(date, new Date(now));
 }
 
-export function matchDateGroupLabel(d: string | null | undefined): string {
-  if (!d) return '';
-  const date = new Date(d);
-  const now = new Date();
-  const yesterday = new Date(now);
-  yesterday.setDate(now.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
+function localDateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+/**
+ * Stable YYYY-MM-DD key in local time for a date. Use for bucket boundary
+ * comparison so labels with no year (`Wednesday, Mar 5`) don't collide across
+ * years.
+ */
+export function matchDateGroupKey(
+  d: string | null | undefined,
+  now: number = Date.now()
+): string {
+  const date = parseLocalDate(d);
+  if (!date) return '';
+  const today = new Date(now);
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (isSameDay(date, yesterday)) return 'yesterday';
+  if (isSameDay(date, today)) return 'today';
+  return localDateKey(date);
+}
+
+/**
+ * Display label for a match date bucket: empty for null inputs, "Yesterday"
+ * for yesterday, otherwise a `Weekday, Mon D` string. Rendering only — do
+ * not use for boundary comparison; use `matchDateGroupKey` instead.
+ */
+export function matchDateGroupLabel(
+  d: string | null | undefined,
+  now: number = Date.now()
+): string {
+  const date = parseLocalDate(d);
+  if (!date) return '';
+  if (matchDateGroupKey(d, now) === 'yesterday') return 'Yesterday';
   return date.toLocaleDateString(undefined, {
     weekday: 'long',
     month: 'short',
     day: 'numeric',
+  });
+}
+
+/**
+ * Bucket a list of matches into adjacent date groups. The input must already
+ * be sorted descending by `playedAt`; the first match in each new bucket
+ * receives its display label, the rest get `null`.
+ */
+export function groupMatchesByDate<T extends { id: string; playedAt: string }>(
+  matches: readonly T[],
+  now: number = Date.now()
+): { match: T; label: string | null }[] {
+  const todayKey = matchDateGroupKey(new Date(now).toISOString(), now);
+  return matches.map((match, i, arr) => {
+    const matchKey = matchDateGroupKey(match.playedAt, now);
+    const prevKey = i > 0 ? matchDateGroupKey(arr[i - 1].playedAt, now) : null;
+    const newGroup = matchKey !== todayKey && matchKey !== prevKey;
+    return {
+      match,
+      label: newGroup ? matchDateGroupLabel(match.playedAt, now) : null,
+    };
   });
 }
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -17,6 +17,31 @@ export function formatDateTime(d: string | null | undefined): string {
   return new Date(d).toLocaleString();
 }
 
+export function isToday(d: string | null | undefined): boolean {
+  if (!d) return false;
+  const date = new Date(d);
+  const now = new Date();
+  return (
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate()
+  );
+}
+
+export function matchDateGroupLabel(d: string | null | undefined): string {
+  if (!d) return '';
+  const date = new Date(d);
+  const now = new Date();
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
 export function getPlayerDisplayName(
   p:
     | { displayName?: string | null; username?: string | null }

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.server.ts
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.server.ts
@@ -46,6 +46,7 @@ export const load: PageServerLoad = async ({
       players,
       queueStatus,
       myFlags,
+      now: Date.now(),
     };
   } catch {
     throw error(500, 'Failed to load leaderboard');

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
@@ -16,7 +16,7 @@
     LeagueRatingHistoryEntry,
     MatchResponse,
   } from '$api3/models';
-  import { isToday, matchDateGroupLabel } from '$lib/utils';
+  import { groupMatchesByDate } from '$lib/utils';
   import type { ActionData, PageData } from './$types';
 
   interface Props {
@@ -32,17 +32,7 @@
   let ratingHistory = $state<LeagueRatingHistoryEntry[] | undefined>(undefined);
 
   const recentMatchGroups = $derived(
-    (data.recentMatches ?? []).map((match, i, arr) => {
-      const today = isToday(match.playedAt);
-      const prev = arr[i - 1];
-      const newGroup =
-        !today &&
-        (prev == null ||
-          isToday(prev.playedAt) ||
-          matchDateGroupLabel(prev.playedAt) !==
-            matchDateGroupLabel(match.playedAt));
-      return { match, label: newGroup ? matchDateGroupLabel(match.playedAt) : null };
-    })
+    groupMatchesByDate(data.recentMatches ?? [], data.now)
   );
 
   $effect(() => {
@@ -130,7 +120,7 @@
     {#each recentMatchGroups as group (group.match.id)}
       {#if group.label}
         <div
-          class="text-muted-foreground px-2 pt-3 pb-1 text-xs font-medium tracking-wide uppercase"
+          class="px-2 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
         >
           {group.label}
         </div>

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
@@ -16,6 +16,7 @@
     LeagueRatingHistoryEntry,
     MatchResponse,
   } from '$api3/models';
+  import { isToday, matchDateGroupLabel } from '$lib/utils';
   import type { ActionData, PageData } from './$types';
 
   interface Props {
@@ -29,6 +30,20 @@
   let selectedEntry = $state<LeaderboardEntryResponse | null>(null);
   let reportModalOpen = $state(false);
   let ratingHistory = $state<LeagueRatingHistoryEntry[] | undefined>(undefined);
+
+  const recentMatchGroups = $derived(
+    (data.recentMatches ?? []).map((match, i, arr) => {
+      const today = isToday(match.playedAt);
+      const prev = arr[i - 1];
+      const newGroup =
+        !today &&
+        (prev == null ||
+          isToday(prev.playedAt) ||
+          matchDateGroupLabel(prev.playedAt) !==
+            matchDateGroupLabel(match.playedAt));
+      return { match, label: newGroup ? matchDateGroupLabel(match.playedAt) : null };
+    })
+  );
 
   $effect(() => {
     data.ratingHistoryPromise.then((res) => (ratingHistory = res.entries));
@@ -112,8 +127,15 @@
   </div>
 
   <div class="flex flex-1 flex-col items-stretch gap-2">
-    {#each data.recentMatches ?? [] as match (match.id)}
-      <MatchCard {match} showMmr={$showMmr} />
+    {#each recentMatchGroups as group (group.match.id)}
+      {#if group.label}
+        <div
+          class="text-muted-foreground px-2 pt-3 pb-1 text-xs font-medium tracking-wide uppercase"
+        >
+          {group.label}
+        </div>
+      {/if}
+      <MatchCard match={group.match} showMmr={$showMmr} />
     {/each}
   </div>
 

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.server.ts
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.server.ts
@@ -159,6 +159,7 @@ export const load: PageServerLoad = async ({
       currentSeason,
       isCurrentSeason: urlSeasonId == null || urlSeasonId === currentSeason?.id,
       myFlags,
+      now: Date.now(),
     };
   } catch {
     throw error(404, 'Player not found');

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.svelte
@@ -20,7 +20,7 @@
     Trash2,
     X,
   } from 'lucide-svelte';
-  import { getPlayerDisplayName, isToday, matchDateGroupLabel } from '$lib/utils';
+  import { getPlayerDisplayName, groupMatchesByDate } from '$lib/utils';
   import type { ActionData, PageData } from './$types';
   import Filter from './components/filter.svelte';
 
@@ -56,19 +56,7 @@
     })
   );
 
-  const matchGroups = $derived(
-    matches.map((match, i, arr) => {
-      const today = isToday(match.playedAt);
-      const prev = arr[i - 1];
-      const newGroup =
-        !today &&
-        (prev == null ||
-          isToday(prev.playedAt) ||
-          matchDateGroupLabel(prev.playedAt) !==
-            matchDateGroupLabel(match.playedAt));
-      return { match, label: newGroup ? matchDateGroupLabel(match.playedAt) : null };
-    })
-  );
+  const matchGroups = $derived(groupMatchesByDate(matches, data.now));
 
   const chartData = $derived(
     data.ratingHistory?.entries?.map((e) => ({
@@ -339,7 +327,7 @@
         {#each matchGroups as group (group.match.id)}
           {#if group.label}
             <div
-              class="text-muted-foreground px-2 pt-3 pb-1 text-xs font-medium tracking-wide uppercase"
+              class="px-2 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
             >
               {group.label}
             </div>

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.svelte
@@ -20,7 +20,7 @@
     Trash2,
     X,
   } from 'lucide-svelte';
-  import { getPlayerDisplayName } from '$lib/utils';
+  import { getPlayerDisplayName, isToday, matchDateGroupLabel } from '$lib/utils';
   import type { ActionData, PageData } from './$types';
   import Filter from './components/filter.svelte';
 
@@ -53,6 +53,20 @@
       return filteredPlayers.every((id) =>
         match.teams.some((t) => t.players.some((p) => p.leaguePlayerId === id))
       );
+    })
+  );
+
+  const matchGroups = $derived(
+    matches.map((match, i, arr) => {
+      const today = isToday(match.playedAt);
+      const prev = arr[i - 1];
+      const newGroup =
+        !today &&
+        (prev == null ||
+          isToday(prev.playedAt) ||
+          matchDateGroupLabel(prev.playedAt) !==
+            matchDateGroupLabel(match.playedAt));
+      return { match, label: newGroup ? matchDateGroupLabel(match.playedAt) : null };
     })
   );
 
@@ -322,19 +336,26 @@
         {#if matches.length === 0}
           <p>No matches found</p>
         {/if}
-        {#each matches as match (match.id)}
-          {@const existingFlag = myFlagForMatch(match.id)}
+        {#each matchGroups as group (group.match.id)}
+          {#if group.label}
+            <div
+              class="text-muted-foreground px-2 pt-3 pb-1 text-xs font-medium tracking-wide uppercase"
+            >
+              {group.label}
+            </div>
+          {/if}
+          {@const existingFlag = myFlagForMatch(group.match.id)}
           <div class="rounded-lg {existingFlag ? 'ring-1 ring-red-400' : ''}">
             <div class="flex items-stretch gap-1">
               <div class="flex-1">
-                <MatchCard {match} showMmr />
+                <MatchCard match={group.match} showMmr />
               </div>
               <button
                 class="rounded p-2 transition-colors hover:bg-muted {existingFlag
                   ? 'text-red-500'
                   : 'text-muted-foreground'}"
                 title={existingFlag ? 'Edit flag' : 'Flag this match'}
-                onclick={() => openFlagDialog(match.id)}
+                onclick={() => openFlagDialog(group.match.id)}
               >
                 <Flag class="h-4 w-4" />
               </button>

--- a/frontend/src/routes/(authed)/settings/+page.svelte
+++ b/frontend/src/routes/(authed)/settings/+page.svelte
@@ -8,6 +8,7 @@
   import Card from '$lib/components/ui/card/card.svelte';
   import { AlertCircle, Check, Copy, Plus, Trash2 } from 'lucide-svelte';
   import type { ActionData, PageData } from './$types';
+  import { formatDate } from '$lib/utils';
 
   interface Props {
     data: PageData;
@@ -18,11 +19,6 @@
   let showCreateDialog = $state(false);
   let isCreating = $state(false);
   let copySuccess = $state(false);
-
-  function formatDate(dateStr?: string): string {
-    if (!dateStr) return 'Never';
-    return new Date(dateStr).toLocaleDateString();
-  }
 
   async function copyToClipboard(text: string) {
     try {
@@ -190,13 +186,13 @@
                   <tr class="border-b border-muted last:border-0">
                     <td class="px-4 py-3 font-medium">{token.name}</td>
                     <td class="px-4 py-3 text-sm text-muted-foreground"
-                      >{formatDate(token.lastUsedAt)}</td
+                      >{formatDate(token.lastUsedAt, 'Never')}</td
                     >
                     <td class="px-4 py-3 text-sm text-muted-foreground"
-                      >{formatDate(token.expiresAt)}</td
+                      >{formatDate(token.expiresAt, 'Never')}</td
                     >
                     <td class="px-4 py-3 text-sm text-muted-foreground"
-                      >{formatDate(token.createdAt)}</td
+                      >{formatDate(token.createdAt, 'Never')}</td
                     >
                     <td class="px-4 py-3 text-right">
                       <form

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.svelte
@@ -8,6 +8,7 @@
   import * as Table from '$lib/components/ui/table';
   import { Flag, CheckCircle, AlertCircle, XCircle } from 'lucide-svelte';
   import { page } from '$app/stores';
+  import { formatDate } from '$lib/utils';
 
   let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -25,14 +26,6 @@
     resolutionNote = '';
     resolveStatus = 'Resolved';
     dialogOpen = true;
-  }
-
-  function formatDate(date: string): string {
-    return new Date(date).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
   }
 
   function truncate(text: string, max: number): string {
@@ -150,7 +143,11 @@
                 {/if}
               </Table.Cell>
               <Table.Cell class="whitespace-nowrap text-sm">
-                {formatDate(flag.createdAt)}
+                {formatDate(flag.createdAt, '—', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
               </Table.Cell>
               <Table.Cell class="text-right">
                 {#if flag.status === 'Open'}

--- a/frontend/src/routes/admin/[orgSlug]/members/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/members/+page.svelte
@@ -22,7 +22,11 @@
     UserPlus,
   } from 'lucide-svelte';
   import { Alert } from '$lib/components/ui/alert';
-  import { getRoleBadgeVariant, isModeratorOrAbove } from '$lib/utils';
+  import {
+    formatDate,
+    getRoleBadgeVariant,
+    isModeratorOrAbove,
+  } from '$lib/utils';
   import type { PageData, ActionData } from './$types';
 
   let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -48,11 +52,6 @@
     } catch {
       alert(`Invite link: ${url}`);
     }
-  }
-
-  function formatDate(dateStr?: string): string {
-    if (!dateStr) return 'Never';
-    return new Date(dateStr).toLocaleDateString();
   }
 </script>
 
@@ -113,7 +112,7 @@
                     <p class="text-xs text-muted-foreground">
                       {link.useCount}{link.maxUses ? `/${link.maxUses}` : ''} uses
                       {#if link.expiresAt}
-                        · Expires {formatDate(link.expiresAt)}
+                        · Expires {formatDate(link.expiresAt, 'Never')}
                       {/if}
                     </p>
                   </div>


### PR DESCRIPTION
## Summary

- Group matches in the recent-matches list on the league page by date. When a match is not from today, a small uppercase header ("Yesterday" or "Wednesday, Mar 5") appears above the first match of each new date bucket.
- Apply the same grouping to the match history on the player page.
- Add `isToday` and `matchDateGroupLabel` helpers in `$lib/utils` for shared use.

<img width="648" height="841" alt="image" src="https://github.com/user-attachments/assets/c8ec2b90-251a-4e86-a723-fd03f93c4070" />

<img width="706" height="928" alt="image" src="https://github.com/user-attachments/assets/f435b00f-3dba-4d62-9997-bdc9deedb05b" />


## Why

When the recent-matches list spans more than one day, comparing per-row timestamps is slow. Grouping by date gives users an at-a-glance boundary between today's matches and older buckets.

## Implementation

- Group label is pre-computed in a `$derived` that walks `data.recentMatches` (and `matches` on the player page) and emits `{ match, label | null }` pairs. The previous attempt used `$state` writes inside the each-block template, which Svelte 5 forbids (`state_unsafe_mutation`); the derived approach keeps render pure.
- The header appears only when the match is not today and the previous match was either today or from a different group, so labels never duplicate within a contiguous bucket.

## Test plan

- [ ] Open a league whose most recent matches span today + yesterday + earlier. Confirm today's matches have no header, yesterday's block has a "Yesterday" header, and earlier blocks have a weekday/date header.
- [ ] Open the same player page and confirm the same grouping applies under "Matches".
- [ ] `npm run check` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Matches in recent-matches and match history lists are now grouped by date with uppercase headers ("Yesterday" or formatted dates like "Wednesday, Mar 5") displayed above each date group for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->