### PR TITLE
feat(frontend): add refresh button to leaderboard

### DIFF
--- a/.changeset/leaderboard-refresh-button.md
+++ b/.changeset/leaderboard-refresh-button.md
@@ -1,0 +1,8 @@
+---
+"frontend": patch
+---
+
+Add a refresh button to the leaderboard page that re-runs all SvelteKit loaders
+via `invalidateAll()` so an organizer can pick up newly reported matches without
+a full page reload. The icon spins while invalidation is in flight and the
+button is disabled to prevent duplicate requests.

--- a/frontend/src/lib/components/season-picker.svelte
+++ b/frontend/src/lib/components/season-picker.svelte
@@ -78,7 +78,7 @@
   items={seasonValues}
 >
   <Select.Trigger
-    class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+    class="flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
     aria-label="Select a season"
   >
     {seasonLabel(selectedSeason, currentSeason)}

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
@@ -10,7 +10,15 @@
   import Label from '$lib/components/ui/label/label.svelte';
   import { showMmr } from '../../../../stores/show-mmr';
   import { Checkbox } from 'bits-ui';
-  import { AlertCircle, Check, CheckCircle, Flag, Minus } from 'lucide-svelte';
+  import { invalidateAll } from '$app/navigation';
+  import {
+    AlertCircle,
+    Check,
+    CheckCircle,
+    Flag,
+    Minus,
+    RefreshCw,
+  } from 'lucide-svelte';
   import type {
     LeaderboardEntryResponse,
     LeagueRatingHistoryEntry,
@@ -29,6 +37,7 @@
   let selectedEntry = $state<LeaderboardEntryResponse | null>(null);
   let reportModalOpen = $state(false);
   let ratingHistory = $state<LeagueRatingHistoryEntry[] | undefined>(undefined);
+  let isRefreshing = $state(false);
 
   $effect(() => {
     data.ratingHistoryPromise.then((res) => (ratingHistory = res.entries));
@@ -37,6 +46,16 @@
   function openStatsModal(entry: LeaderboardEntryResponse) {
     selectedEntry = entry;
     statsModalOpen = true;
+  }
+
+  async function refresh() {
+    if (isRefreshing) return;
+    isRefreshing = true;
+    try {
+      await invalidateAll();
+    } finally {
+      isRefreshing = false;
+    }
   }
 
   async function fetchRecentMatch(
@@ -73,11 +92,20 @@
     </Alert>
   {/if}
 
-  {#if data.seasons != null && data.seasons.length > 1 && data.currentSeason}
-    <div class="self-end">
+  <div class="flex justify-end gap-2">
+    {#if data.seasons != null && data.seasons.length > 1 && data.currentSeason}
       <SeasonPicker seasons={data.seasons} currentSeason={data.currentSeason} />
-    </div>
-  {/if}
+    {/if}
+    <Button
+      variant="outline"
+      size="icon"
+      onclick={refresh}
+      disabled={isRefreshing}
+      aria-label="Refresh"
+    >
+      <RefreshCw class="h-4 w-4 {isRefreshing ? 'animate-spin' : ''}" />
+    </Button>
+  </div>
 
   <div class="flex">
     <div class="flex flex-1 items-center gap-3">


### PR DESCRIPTION
Adds a refresh icon to the top-right of the leaderboard page that re-runs all SvelteKit loaders via `invalidateAll()`, so an organizer can pick up newly reported matches without a hard page reload. The icon spins while invalidation is in flight and the button is disabled to prevent duplicate requests.

Also shrinks `SeasonPicker`'s trigger from `w-full` to its intrinsic width so it sits naturally next to the new button rather than forcing the whole flex row to full width.

Includes a patch-level frontend changeset.

<img width="366" height="726" alt="image" src="https://github.com/user-attachments/assets/a087c143-10f9-417b-bd0c-4b7d745669a4" />
<img width="2168" height="850" alt="image" src="https://github.com/user-attachments/assets/1891efe5-242e-4586-84f2-737df95d3539" />
