### PR TITLE
fix(frontend): restore PWA pull-to-refresh dropped in v3 migration

### DIFF
--- a/.changeset/restore-pwa-pull-to-refresh.md
+++ b/.changeset/restore-pwa-pull-to-refresh.md
@@ -1,0 +1,9 @@
+---
+"frontend": patch
+---
+
+Restore pull-to-refresh in the installed PWA. The gesture was silently dropped
+during the v3 multi-tenancy migration, which rewrote the authenticated layout
+and never re-mounted the `PullToRefresh` component. It is wired back into the
+`(authed)` shell, and the refresh indicator now slides out from beneath the
+fixed app-shell header instead of appearing behind it.

--- a/frontend/src/lib/components/pull-to-refresh.svelte
+++ b/frontend/src/lib/components/pull-to-refresh.svelte
@@ -54,15 +54,15 @@
 </script>
 
 <svelte:window
-  on:touchstart={onTouchStart}
-  on:touchmove={onTouchMove}
-  on:touchend={onTouchEnd}
+  ontouchstart={onTouchStart}
+  ontouchmove={onTouchMove}
+  ontouchend={onTouchEnd}
 />
 
 {#if pullDistance > 0}
   <div
     class="pointer-events-none fixed left-0 right-0 z-50 flex justify-center"
-    style="top: calc(env(safe-area-inset-top) + {pullDistance -
+    style="top: calc(env(safe-area-inset-top) + var(--header-height) + {pullDistance -
       40}px); opacity: {Math.min(pullDistance / THRESHOLD, 1)}"
   >
     <div class="rounded-full border bg-card p-2 shadow-md">

--- a/frontend/src/routes/(authed)/+layout.svelte
+++ b/frontend/src/routes/(authed)/+layout.svelte
@@ -5,6 +5,7 @@
   import type { Snippet } from 'svelte';
   import Header from './components/header.svelte';
   import Navbar from './components/navbar.svelte';
+  import PullToRefresh from '$lib/components/pull-to-refresh.svelte';
   import type { LayoutData } from './$types';
 
   interface Props {
@@ -32,6 +33,7 @@
   </style>
 </svelte:head>
 
+<PullToRefresh />
 <Header
   organizations={data.organizations}
   displayName={data.displayName}


### PR DESCRIPTION
## What & why

Pull-to-refresh in the installed PWA stopped working after the multi-tenancy work. It wasn't a subtle gesture/scroll regression — the v3 API migration (`c1858f0`) **rewrote `(authed)/+layout.svelte` from scratch and never re-mounted `<PullToRefresh />`**. The component file itself survived untouched but was left orphaned (nothing imported it). The later app-shell header PR (`e8ec605`) then added a `fixed` top header, so a naïve re-mount would have rendered the spinner *behind* it.

All the other PWA pieces from the original feature (`79cf0c3`) survived the migration intact and needed no changes: the `viewport-fit=cover` + Apple meta tags in `app.html`, `overscroll-behavior: none` + safe-area insets in `app.pcss`, and the web manifest (`display: standalone`, etc.).

## Changes

- **`(authed)/+layout.svelte`** — re-import and mount `<PullToRefresh />` in the authenticated shell (the actual regression fix).
- **`pull-to-refresh.svelte`**:
  - Offset the refresh indicator by `var(--header-height)` so it slides out from *beneath* the fixed app-shell header instead of behind it.
  - Modernize `<svelte:window on:touch…>` → `ontouch…` (the legacy `on:` directive warns in Svelte 5 runes mode, which the rest of the codebase uses).
- **`.changeset/restore-pwa-pull-to-refresh.md`** — `frontend: patch`.

The gesture still keys off standalone-mode + `window.scrollY === 0` + `invalidateAll()`, which remain correct under the nested `[orgSlug]/[leagueSlug]` routing (the header is `fixed`, so it doesn't affect document scroll).

## Testing

- `npm run check` → 0 errors (pre-existing warnings only, none in changed files).
- `npm run lint` → 0 errors (pre-existing warnings only, none in changed files).
- ⚠️ Not yet verified on a physical device — pull-to-refresh only activates in standalone PWA mode, so the gesture itself should be smoke-tested on an installed iOS/Android home-screen app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored pull-to-refresh functionality in the installed PWA that was lost during the v3 migration.
  * Improved refresh indicator positioning—now slides beneath the fixed app header during pull gestures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->