### PR TITLE
fix(frontend): harden PWA pull-to-refresh (review findings)

### DIFF
--- a/.changeset/harden-pull-to-refresh.md
+++ b/.changeset/harden-pull-to-refresh.md
@@ -1,0 +1,20 @@
+---
+"frontend": patch
+---
+
+Harden the PWA pull-to-refresh gesture:
+
+- Ignore pulls that start on surfaces owning their own touch gestures (the
+  `/random` touch randomizer), so its multi-finger flow no longer triggers a
+  spurious refresh.
+- Only attach the global touch listeners in standalone (installed) mode, and
+  resolve standalone status once instead of on every gesture.
+- Handle `touchcancel` so an interrupted pull no longer leaves the spinner
+  stuck on screen.
+- Restrict the gesture to a single finger and only commit once the last finger
+  lifts, fixing multi-touch origin/commit glitches.
+- Surface a brief error state (instead of silently resetting) when the refresh
+  fails, and expose the refresh state to assistive tech via an `aria-live`
+  status region.
+- Render the indicator beneath the app-shell header (`z-20`) so it emerges from
+  under the header as intended.

--- a/frontend/e2e/pull-to-refresh.spec.ts
+++ b/frontend/e2e/pull-to-refresh.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type CDPSession, type Page } from '@playwright/test';
+
+// Pull-to-refresh is a window-level touch gesture gated to installed-PWA mode.
+// We can't install a PWA in automation, so we drive the component's own
+// standalone signal (navigator.standalone, which isStandaloneMode() checks) via
+// an init script, and dispatch real touch input through Chromium CDP
+// (Input.dispatchTouchEvent).
+
+test.use({ hasTouch: true });
+
+const LEAGUE = '/test-org/test-league';
+const indicator = (page: Page) => page.locator('[role="status"].fixed');
+
+// Make isStandaloneMode() return true before any page script runs.
+async function markStandalone(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(window.navigator, 'standalone', {
+      value: true,
+      configurable: true,
+    });
+  });
+}
+
+async function cdp(page: Page) {
+  const client = await page.context().newCDPSession(page);
+  // Coarse pointer / no hover so /random renders its touch surface.
+  await client.send('Emulation.setEmulatedMedia', {
+    features: [
+      { name: 'hover', value: 'none' },
+      { name: 'pointer', value: 'coarse' },
+    ],
+  });
+  return client;
+}
+
+async function pull(
+  client: CDPSession,
+  { x = 180, fromY = 90, toY = 380, steps = 14, release = true } = {}
+) {
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x, y: fromY }],
+  });
+  for (let i = 1; i <= steps; i++) {
+    const y = Math.round(fromY + ((toY - fromY) * i) / steps);
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x, y }],
+    });
+  }
+  if (release) {
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchEnd',
+      touchPoints: [],
+    });
+  }
+}
+
+async function waitForShell(page: Page) {
+  await expect(page.getByLabel('Settings menu')).toBeVisible();
+  await page.waitForTimeout(400); // let the layout's onMount attach listeners
+}
+
+test('does NOT attach the gesture outside standalone (browser tab)', async ({
+  page,
+}) => {
+  const client = await cdp(page); // note: NOT marked standalone
+  await page.goto(LEAGUE);
+  await waitForShell(page);
+
+  expect(await page.evaluate(() => !!navigator.standalone)).toBe(false);
+  await pull(client, { release: false });
+  await expect(indicator(page)).toHaveCount(0);
+  await pull(client); // release
+  await expect(indicator(page)).toHaveCount(0);
+});
+
+test('standalone: pull past threshold shows the indicator and refetches data', async ({
+  page,
+}) => {
+  await markStandalone(page);
+  const client = await cdp(page);
+  await page.goto(LEAGUE);
+  await waitForShell(page);
+  expect(await page.evaluate(() => navigator.standalone)).toBe(true);
+
+  // invalidateAll() re-runs SvelteKit load functions -> observable as a
+  // __data.json refetch.
+  const refetch = page.waitForRequest((r) => r.url().includes('__data.json'), {
+    timeout: 10_000,
+  });
+
+  await pull(client, { release: false }); // hold the pull
+  await expect(indicator(page)).toBeVisible();
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+  }); // release past threshold -> commit
+  await refetch; // throws if invalidateAll never fired
+  await expect(indicator(page)).toHaveCount(0); // resets to idle
+});
+
+test('standalone: /random touch surface is opted out (with positive control)', async ({
+  page,
+}) => {
+  await markStandalone(page);
+  const client = await cdp(page);
+  await page.goto('/random');
+
+  const surface = page.getByLabel('Touch randomizer surface');
+  await expect(surface).toBeVisible();
+  expect(await page.evaluate(() => navigator.standalone)).toBe(true);
+  await page.waitForTimeout(400);
+
+  // A long downward drag on the randomizer surface must NOT arm pull-to-refresh.
+  await pull(client, { x: 180, fromY: 220, toY: 520, release: false });
+  await expect(indicator(page)).toHaveCount(0);
+  await pull(client, { x: 180, fromY: 220, toY: 520 }); // release
+  await expect(indicator(page)).toHaveCount(0);
+
+  // Positive control: the SAME standalone context DOES arm the gesture on a
+  // normal page — proving the no-show above was the opt-out, not a dead gesture.
+  await page.goto(LEAGUE);
+  await waitForShell(page);
+  await pull(client, { release: false });
+  await expect(indicator(page)).toBeVisible();
+  await pull(client); // release
+});

--- a/frontend/src/lib/components/pull-to-refresh.svelte
+++ b/frontend/src/lib/components/pull-to-refresh.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { invalidateAll } from '$app/navigation';
   import { RefreshCw } from 'lucide-svelte';
 
   const THRESHOLD = 80;
   const MAX_PULL = 120;
   const DAMPING = 0.4;
+  const ERROR_DISPLAY_MS = 1500;
 
+  // Only these drive the UI; startY/isPulling are gesture-internal, so plain
+  // `let` is enough (no need for $state reactivity).
   let pullDistance = $state(0);
   let isRefreshing = $state(false);
-  let startY = $state(0);
-  let isPulling = $state(false);
+  let refreshFailed = $state(false);
+  let startY = 0;
+  let isPulling = false;
 
   function isStandaloneMode(): boolean {
     return (
@@ -18,15 +23,26 @@
     );
   }
 
+  function resetPull() {
+    isPulling = false;
+    if (!isRefreshing) pullDistance = 0;
+  }
+
   function onTouchStart(e: TouchEvent) {
-    if (window.scrollY !== 0 || isRefreshing || !isStandaloneMode()) return;
+    // Single-finger pull, at the very top, while idle. Bail on surfaces that
+    // own their own touch gestures (e.g. the /random touch randomizer).
+    if (isRefreshing || window.scrollY !== 0 || e.touches.length !== 1) return;
+    if ((e.target as Element | null)?.closest('[data-no-pull-to-refresh]'))
+      return;
     startY = e.touches[0].clientY;
     isPulling = true;
   }
 
   function onTouchMove(e: TouchEvent) {
     if (!isPulling) return;
-    const deltaY = e.touches[0].clientY - startY;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const deltaY = touch.clientY - startY;
     if (deltaY < 0) {
       pullDistance = 0;
       return;
@@ -34,42 +50,71 @@
     pullDistance = Math.min(deltaY * DAMPING, MAX_PULL);
   }
 
-  async function onTouchEnd() {
-    if (!isPulling) return;
+  async function onTouchEnd(e: TouchEvent) {
+    // Commit only once the last finger lifts, so a multi-finger gesture can't
+    // fire the refresh early.
+    if (!isPulling || e.touches.length > 0) return;
     isPulling = false;
 
-    if (pullDistance >= THRESHOLD) {
-      isRefreshing = true;
-      pullDistance = THRESHOLD;
-      try {
-        await invalidateAll();
-      } finally {
-        isRefreshing = false;
-        pullDistance = 0;
-      }
-    } else {
+    if (pullDistance < THRESHOLD) {
       pullDistance = 0;
+      return;
+    }
+
+    isRefreshing = true;
+    pullDistance = THRESHOLD;
+    try {
+      await invalidateAll();
+      isRefreshing = false;
+      pullDistance = 0;
+    } catch (err) {
+      // Don't reset as if it succeeded — surface a brief error state.
+      console.error('Pull-to-refresh failed', err);
+      isRefreshing = false;
+      refreshFailed = true;
+      setTimeout(() => {
+        refreshFailed = false;
+        pullDistance = 0;
+      }, ERROR_DISPLAY_MS);
     }
   }
-</script>
 
-<svelte:window
-  ontouchstart={onTouchStart}
-  ontouchmove={onTouchMove}
-  ontouchend={onTouchEnd}
-/>
+  onMount(() => {
+    // The feature is PWA-only; outside standalone mode attach nothing so
+    // ordinary browser users pay no touch-listener cost. Standalone status is
+    // fixed for the session, so it's resolved once here, not per gesture.
+    if (!isStandaloneMode()) return;
+    window.addEventListener('touchstart', onTouchStart, { passive: true });
+    window.addEventListener('touchmove', onTouchMove, { passive: true });
+    window.addEventListener('touchend', onTouchEnd);
+    window.addEventListener('touchcancel', resetPull);
+    return () => {
+      window.removeEventListener('touchstart', onTouchStart);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
+      window.removeEventListener('touchcancel', resetPull);
+    };
+  });
+</script>
 
 {#if pullDistance > 0}
   <div
-    class="pointer-events-none fixed left-0 right-0 z-50 flex justify-center"
+    role="status"
+    aria-live="polite"
+    class="pointer-events-none fixed left-0 right-0 z-20 flex justify-center"
     style="top: calc(env(safe-area-inset-top) + var(--header-height) + {pullDistance -
       40}px); opacity: {Math.min(pullDistance / THRESHOLD, 1)}"
   >
     <div class="rounded-full border bg-card p-2 shadow-md">
       <RefreshCw
-        class="h-6 w-6 text-primary {isRefreshing ? 'animate-spin' : ''}"
+        class="h-6 w-6 {refreshFailed
+          ? 'text-destructive'
+          : 'text-primary'} {isRefreshing ? 'animate-spin' : ''}"
         style="transform: rotate({(pullDistance / THRESHOLD) * 360}deg)"
       />
     </div>
+    <span class="sr-only">
+      {refreshFailed ? 'Refresh failed' : isRefreshing ? 'Refreshing' : ''}
+    </span>
   </div>
 {/if}

--- a/frontend/src/routes/(authed)/random/+page.svelte
+++ b/frontend/src/routes/(authed)/random/+page.svelte
@@ -377,6 +377,7 @@
         role="application"
         aria-label="Touch randomizer surface"
         class="relative flex-1 touch-none select-none overflow-hidden bg-muted"
+        data-no-pull-to-refresh
         ontouchstart={handleTouchStart}
         ontouchmove={handleTouchMove}
         ontouchend={handleTouchEnd}


### PR DESCRIPTION
Follow-up to #337 addressing the `/code-review max` findings on the restored pull-to-refresh component. All changes are confined to the pull-to-refresh component plus a one-line opt-out attribute on the `/random` touch surface.

## Findings addressed

| # | Finding | Fix |
|---|---------|-----|
| 1 | On `/random` (a fixed full-bleed touch surface where `scrollY` stays 0), PullToRefresh's window listeners fired concurrently — spurious spinner / possible `invalidateAll()` mid-game | `[data-no-pull-to-refresh]` opt-out (added to the `/random` surface); `onTouchStart` bails when the gesture starts inside such an element, and now only starts on a single finger |
| 2 | No `touchcancel` handler → interrupted pull left the spinner stuck | Added a `touchcancel` → `resetPull` listener |
| 3 | Global touch listeners attached on every authed route for all users; `matchMedia` rebuilt per `touchstart` | Listeners now attach in `onMount` **only in standalone mode**, and standalone status is resolved once |
| 4 | `invalidateAll()` rejection swallowed by `try/finally` — failed refresh looked successful | `catch` logs and shows a brief destructive-colored error state |
| 5 | Multi-touch: first finger lift committed early; 2nd `touchstart` overwrote `startY` | Single-finger-only start (`e.touches.length !== 1`) + commit only when the last finger lifts (`e.touches.length > 0` guard) |
| 6 | `e.touches[0].clientY` dereferenced without a length guard | Single-finger guard on start + `if (!touch) return` in move |
| 7 | Cosmetic: z-50 spinner painted over the z-30 header during early pull | Indicator lowered to `z-20` so it emerges from beneath the header |
| 8 | Refresh state not announced to assistive tech | `role="status"` + `aria-live="polite"` region with `sr-only` text |
| 9 | `startY`/`isPulling` were `$state` but never used in the template | Changed to plain `let` |

## Not changed (deliberately)
- "No pull-to-refresh in a normal browser tab" — intentional; the feature is PWA-only by design.
- `invalidateAll()` re-running all loaders (incl. the 401 path on `profileLoadFailed`) — that's standard refresh semantics, also triggered by ordinary navigation; pre-existing and out of scope.

## Testing
- `npm run check` → 0 errors (pre-existing warnings only).
- `npm run lint` → 0 errors (pre-existing warnings only).
- `npm run build` → succeeds.
- ⚠️ Still needs a smoke test on an installed iOS/Android PWA: pull-to-refresh on a normal page, the `/random` touch flow (no spurious spinner), and an interrupted/cancelled pull.