### PR TITLE
fix(api): delete match flags when deleting a match

### DIFF
--- a/.changeset/delete-match-with-flags.md
+++ b/.changeset/delete-match-with-flags.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Fix match deletion failing for any match that has been flagged. `DeleteMatchAsync` now removes the match's `match_flags` rows inside the same transaction before deleting the match, so the restricted `fk_match_flags_match` foreign key no longer blocks the delete.

--- a/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
+++ b/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
@@ -407,6 +407,53 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
     }
 
     [Fact]
+    public async Task DeleteMatch_WithFlag_RemovesMatchAndFlag()
+    {
+        // A flag references the match via a restricted FK (fk_match_flags_match).
+        // Deleting a flagged match must clean up the flag first, otherwise the
+        // delete fails with a foreign key violation.
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+        await CreateSeason(org.Id, league.Id);
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                ]
+            });
+        submitResponse.EnsureSuccessStatusCode();
+        var match = await ReadJsonAsync<MatchResponse>(submitResponse);
+
+        var flagResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/match-flags",
+            new CreateMatchFlagRequest { MatchId = match!.Id, Reason = "Wrong score" });
+        flagResponse.EnsureSuccessStatusCode();
+
+        var deleteResponse = await Client.DeleteAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/{match.Id}");
+
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+        Assert.Null(await dbContext.V3Matches.FirstOrDefaultAsync(m => m.Id == match.Id));
+        Assert.False(await dbContext.V3MatchFlags.AnyAsync(f => f.MatchId == match.Id));
+    }
+
+    [Fact]
     public async Task DeleteMatch_MostRecentMatch_RestoresPreviousRatings()
     {
         var org = await CreateOrganization();

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -453,6 +453,13 @@ public class V3MatchesService(
             .ToListAsync();
         dbContext.RatingHistories.RemoveRange(ratingHistories);
 
+        // Flags reference the match with a restricted FK, so they must go before
+        // the match itself or Postgres rejects the delete (fk_match_flags_match).
+        var matchFlags = await dbContext.V3MatchFlags
+            .Where(f => f.MatchId == matchId)
+            .ToListAsync();
+        dbContext.V3MatchFlags.RemoveRange(matchFlags);
+
         foreach (var team in match.Teams)
         {
             dbContext.Set<MatchTeamPlayer>().RemoveRange(team.Players);


### PR DESCRIPTION
## Problem

Deleting a match in production fails with a 500 whenever the match has been **flagged**. OTel/Loki showed a Postgres FK violation:

```
23503: update or delete on table "matches" violates foreign key
constraint "fk_match_flags_match" on table "match_flags"
```

`V3MatchesService.DeleteMatchAsync` removes rating histories, team players, teams, and the match itself, but never the `match_flags` rows that reference it. The FK is `DeleteBehavior.Restrict` (no cascade), so the final `DELETE FROM matches` is rejected and the whole transaction rolls back. Since flagged matches are exactly the ones a moderator wants to delete, this hit a common path.

## Fix

Delete the match's `match_flags` rows inside the same transaction, before removing the match — consistent with how the other child rows are handled.

## Test

Adds `DeleteMatch_WithFlag_RemovesMatchAndFlag`: submits a match, flags it, deletes it, and asserts the delete returns `204` and both the match and flag are gone. Verified it **fails without the fix** (`500 InternalServerError`) and passes with it. All `DeleteMatch*` tests pass.

Includes an `api` patch changeset.