### PR TITLE
feat(frontend): show and edit flagged match on admin flags page

### DIFF
--- a/.changeset/admin-flags-show-and-edit-match.md
+++ b/.changeset/admin-flags-show-and-edit-match.md
@@ -1,0 +1,6 @@
+---
+"frontend": minor
+---
+
+Show the flagged match inline on the admin match-flags page and let moderators
+edit (and recalculate) the match before resolving or dismissing the flag.

--- a/frontend/e2e/match-flags.spec.ts
+++ b/frontend/e2e/match-flags.spec.ts
@@ -2,12 +2,13 @@ import { test, expect } from '@playwright/test';
 
 const FLAGS_PAGE = '/admin/test-org/leagues/test-league/match-flags';
 
-// The seed (scripts/seed-data.sql) creates two open flags on current-season
-// Test League matches:
-//   A: "Wrong score reported on this match (e2e A)."   flagged by Alice Anderson
-//   B: "Possible duplicate match entry (e2e B)."        flagged by Bob Brown
+// The seed (scripts/seed-data.sql) creates three open flags in Test League:
+//   A: "Wrong score reported on this match (e2e A)."  current season, by Alice
+//   B: "Possible duplicate match entry (e2e B)."      current season, by Bob
+//   C: "Match from a previous season (e2e C)."        past season, by Carol
 const FLAG_A_REASON = 'Wrong score reported on this match (e2e A).';
 const FLAG_B_REASON = 'Possible duplicate match entry (e2e B).';
+const FLAG_C_REASON = 'Match from a previous season (e2e C).';
 
 const cardWithReason = (
   page: import('@playwright/test').Page,
@@ -60,6 +61,24 @@ test.describe('Admin match flags', () => {
     await expect(
       page.getByRole('alert').filter({ hasText: 'Match updated' })
     ).toBeVisible();
+  });
+
+  test('disables edit/recalc for a flag on a past-season match', async ({
+    page,
+  }) => {
+    await page.goto(FLAGS_PAGE);
+
+    const card = cardWithReason(page, FLAG_C_REASON);
+    await expect(card).toBeVisible();
+    // The match still renders for review...
+    await expect(card.getByText('vs.')).toBeVisible();
+    // ...but Edit/Recalc are disabled because the API rejects edits and
+    // recalculation outside the current season, with an explanation shown.
+    await expect(card.getByTestId('match-flag-edit')).toBeDisabled();
+    await expect(card.getByTestId('match-flag-recalculate')).toBeDisabled();
+    await expect(card.getByText(/past season/i)).toBeVisible();
+    // Resolving/dismissing is still available for old flags.
+    await expect(card.getByTestId('match-flag-resolve')).toBeEnabled();
   });
 
   test('resolves a flag after reviewing the match', async ({ page }) => {

--- a/frontend/e2e/match-flags.spec.ts
+++ b/frontend/e2e/match-flags.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+const FLAGS_PAGE = '/admin/test-org/leagues/test-league/match-flags';
+
+// The seed (scripts/seed-data.sql) creates two open flags on current-season
+// Test League matches:
+//   A: "Wrong score reported on this match (e2e A)."   flagged by Alice Anderson
+//   B: "Possible duplicate match entry (e2e B)."        flagged by Bob Brown
+const FLAG_A_REASON = 'Wrong score reported on this match (e2e A).';
+const FLAG_B_REASON = 'Possible duplicate match entry (e2e B).';
+
+const cardWithReason = (
+  page: import('@playwright/test').Page,
+  reason: string
+) => page.getByTestId('match-flag-card').filter({ hasText: reason });
+
+test.describe('Admin match flags', () => {
+  test('shows the flagged match inline with who flagged it and why', async ({
+    page,
+  }) => {
+    await page.goto(FLAGS_PAGE);
+    await expect(
+      page.getByRole('heading', { name: 'Flagged Matches' })
+    ).toBeVisible();
+
+    const card = cardWithReason(page, FLAG_A_REASON);
+    await expect(card).toBeVisible();
+    // The flag's match is rendered inline (MatchCard shows the "vs." separator).
+    await expect(card.getByText('vs.')).toBeVisible();
+    // Flag metadata is present alongside the match.
+    await expect(card.getByText(/Flagged by Alice Anderson/)).toBeVisible();
+    await expect(card.getByText(FLAG_A_REASON)).toBeVisible();
+  });
+
+  test('edits the flagged match from the flag, leaving rating history intact', async ({
+    page,
+  }) => {
+    await page.goto(FLAGS_PAGE);
+
+    const card = cardWithReason(page, FLAG_A_REASON);
+    await card.getByTestId('match-flag-edit').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Edit match')).toBeVisible();
+    // The dialog pre-fills the flagged match's two teams.
+    await expect(dialog.getByText('Team 1', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Team 2', { exact: true })).toBeVisible();
+
+    // Test League is fixed-target (winning_score = 10), so submit a valid
+    // winner/loser pair. Re-running with the same values is idempotent, which
+    // keeps this test safe under CI retries.
+    const scoreInputs = dialog.locator('input[type="number"]');
+    await scoreInputs.nth(0).fill('10');
+    await scoreInputs.nth(1).fill('5');
+    await dialog.getByRole('button', { name: 'Save match' }).click();
+
+    // A successful PATCH closes the dialog and surfaces a success alert.
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    await expect(
+      page.getByRole('alert').filter({ hasText: 'Match updated' })
+    ).toBeVisible();
+  });
+
+  test('resolves a flag after reviewing the match', async ({ page }) => {
+    await page.goto(FLAGS_PAGE);
+
+    const card = cardWithReason(page, FLAG_B_REASON);
+    await expect(card).toBeVisible();
+
+    // Idempotent under retries: only drive the resolve flow while the flag is
+    // still open; on a retry the flag is already resolved and we just assert it.
+    const resolveButton = card.getByTestId('match-flag-resolve');
+    if (await resolveButton.count()) {
+      await resolveButton.click();
+
+      const dialog = page.getByRole('dialog');
+      await expect(
+        dialog.getByRole('heading', { name: 'Resolve Match Flag' })
+      ).toBeVisible();
+      // The admin sees the match while deciding how to resolve.
+      await expect(dialog.getByText('vs.')).toBeVisible();
+
+      await dialog.getByRole('button', { name: 'Resolve Flag' }).click();
+      await expect(
+        page
+          .getByRole('alert')
+          .filter({ hasText: 'Flag resolved successfully' })
+      ).toBeVisible();
+    }
+
+    // Resolved flags expose no further actions.
+    await expect(card.getByTestId('match-flag-resolve')).toHaveCount(0);
+    await expect(card.getByTestId('match-flag-edit')).toHaveCount(0);
+  });
+});

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.server.ts
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.server.ts
@@ -1,7 +1,8 @@
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { getApiErrorDetails } from '$lib/server/api/apiError';
-import { MatchFlagStatus } from '$api3';
+import { resolveOrgAndLeagueIds } from '$lib/server/resolveIds';
+import { MatchFlagStatus, type MatchResponse } from '$api3';
 
 const isMatchFlagStatus = (value: string): value is MatchFlagStatus =>
   (Object.values(MatchFlagStatus) as string[]).includes(value);
@@ -28,9 +29,32 @@ export const load: PageServerLoad = async ({
       apiClientV3.leaguePlayersApi.listPlayers(orgId, leagueId),
     ]);
 
+    // Resolving a flag means inspecting (and often editing) the match it's
+    // about, so fetch each referenced match. Multiple flags can point at the
+    // same match, and a match may have been deleted — fetch unique ids and
+    // tolerate misses so a single 404 doesn't break the page.
+    const uniqueMatchIds = [...new Set(flags.map((flag) => flag.matchId))];
+    const matchEntries = await Promise.all(
+      uniqueMatchIds.map(async (matchId) => {
+        try {
+          const match = await apiClientV3.matchesApi.getMatch(
+            orgId,
+            leagueId,
+            matchId
+          );
+          return [matchId, match] as const;
+        } catch {
+          return [matchId, null] as const;
+        }
+      })
+    );
+    const matchesById: Record<string, MatchResponse | null> =
+      Object.fromEntries(matchEntries);
+
     return {
       flags,
       players,
+      matchesById,
       statusFilter: statusFilter ?? null,
     };
   } catch {
@@ -74,5 +98,76 @@ export const actions = {
     }
 
     return { success: true, message: 'Flag resolved successfully' };
+  },
+
+  edit: async ({ request, params, locals: { apiClientV3 } }) => {
+    const formData = await request.formData();
+    const matchId = formData.get('matchId') as string;
+    const teamsRaw = formData.get('teams') as string;
+    if (!matchId || !teamsRaw)
+      return fail(400, {
+        success: false,
+        message: 'matchId and teams are required',
+      });
+
+    let parsedTeams: Array<{
+      score: number;
+      players: { leaguePlayerId: string }[];
+    }>;
+    try {
+      parsedTeams = JSON.parse(teamsRaw);
+    } catch {
+      return fail(400, { success: false, message: 'Invalid teams payload' });
+    }
+
+    const ctx = await resolveOrgAndLeagueIds(apiClientV3, params);
+    if (!ctx)
+      return fail(404, { success: false, message: 'Org or league not found' });
+
+    try {
+      await apiClientV3.matchesApi.updateMatch(
+        ctx.orgId,
+        ctx.leagueId,
+        matchId,
+        { teams: parsedTeams }
+      );
+      return { success: true, message: 'Match updated' };
+    } catch (err) {
+      const { status, message } = await getApiErrorDetails(
+        err,
+        'Failed to update match'
+      );
+      return fail(status, { success: false, message });
+    }
+  },
+
+  recalculate: async ({ request, params, locals: { apiClientV3 } }) => {
+    const formData = await request.formData();
+    const fromMatchIdRaw = formData.get('fromMatchId') as string | null;
+    const fromMatchId = fromMatchIdRaw?.trim()
+      ? fromMatchIdRaw.trim()
+      : undefined;
+
+    const ctx = await resolveOrgAndLeagueIds(apiClientV3, params);
+    if (!ctx)
+      return fail(404, { success: false, message: 'Org or league not found' });
+
+    try {
+      const result = await apiClientV3.matchesApi.recalculateMatches(
+        ctx.orgId,
+        ctx.leagueId,
+        fromMatchId
+      );
+      return {
+        success: true,
+        message: `Recalculated ${result.matchCount} match${result.matchCount === 1 ? '' : 'es'}`,
+      };
+    } catch (err) {
+      const { status, message } = await getApiErrorDetails(
+        err,
+        'Failed to recalculate MMR'
+      );
+      return fail(status, { success: false, message });
+    }
   },
 } satisfies Actions;

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.server.ts
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { getApiErrorDetails } from '$lib/server/api/apiError';
 import { resolveOrgAndLeagueIds } from '$lib/server/resolveIds';
-import { MatchFlagStatus, type MatchResponse } from '$api3';
+import { MatchFlagStatus, ResponseError, type MatchResponse } from '$api3';
 
 const isMatchFlagStatus = (value: string): value is MatchFlagStatus =>
   (Object.values(MatchFlagStatus) as string[]).includes(value);
@@ -20,19 +20,25 @@ export const load: PageServerLoad = async ({
       : undefined;
 
   try {
-    const [flags, players] = await Promise.all([
+    const [flags, players, currentSeasonId] = await Promise.all([
       apiClientV3.adminMatchFlagsApi.listAllFlags(
         orgId,
         leagueId,
         statusFilter
       ),
       apiClientV3.leaguePlayersApi.listPlayers(orgId, leagueId),
+      // Only current-season matches can be edited or recalculated (the API
+      // rejects the rest), so the page needs the current season to gate those
+      // actions. Tolerate no active season — everything is then read-only.
+      apiClientV3.seasonsApi
+        .getCurrentSeason(orgId, leagueId)
+        .then((season) => season.id)
+        .catch(() => null),
     ]);
 
     // Resolving a flag means inspecting (and often editing) the match it's
     // about, so fetch each referenced match. Multiple flags can point at the
-    // same match, and a match may have been deleted — fetch unique ids and
-    // tolerate misses so a single 404 doesn't break the page.
+    // same match, so fetch unique ids in parallel.
     const uniqueMatchIds = [...new Set(flags.map((flag) => flag.matchId))];
     const matchEntries = await Promise.all(
       uniqueMatchIds.map(async (matchId) => {
@@ -43,8 +49,14 @@ export const load: PageServerLoad = async ({
             matchId
           );
           return [matchId, match] as const;
-        } catch {
-          return [matchId, null] as const;
+        } catch (err) {
+          // A deleted match is an expected per-flag state (null renders as "no
+          // longer exists"). Anything else is a real failure that must not
+          // masquerade as a deletion — let it surface as a page error.
+          if (err instanceof ResponseError && err.response.status === 404) {
+            return [matchId, null] as const;
+          }
+          throw err;
         }
       })
     );
@@ -55,6 +67,7 @@ export const load: PageServerLoad = async ({
       flags,
       players,
       matchesById,
+      currentSeasonId,
       statusFilter: statusFilter ?? null,
     };
   } catch {

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.svelte
@@ -6,6 +6,7 @@
   import * as Dialog from '$lib/components/ui/dialog';
   import { Label } from '$lib/components/ui/label';
   import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
+  import { Badge } from '$lib/components/ui/badge';
   import MatchCard from '$lib/components/match-card/match-card.svelte';
   import EditMatchDialog from '$lib/components/admin/edit-match-dialog.svelte';
   import {
@@ -18,7 +19,7 @@
   } from 'lucide-svelte';
   import { page } from '$app/stores';
   import { formatDate } from '$lib/utils';
-  import type { MatchResponse } from '$api3';
+  import type { MatchResponse, MatchFlagStatus } from '$api3';
 
   let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -54,6 +55,30 @@
     month: 'short',
     day: 'numeric',
   } as const;
+
+  const STATUS_META: Record<
+    MatchFlagStatus,
+    { label: string; icon: typeof Flag; class: string }
+  > = {
+    Open: {
+      label: 'Open',
+      icon: Flag,
+      class:
+        'border-transparent bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    },
+    Resolved: {
+      label: 'Resolved',
+      icon: CheckCircle,
+      class:
+        'border-transparent bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    },
+    Dismissed: {
+      label: 'Dismissed',
+      icon: XCircle,
+      class:
+        'border-transparent bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+    },
+  };
 
   const statusTabs = [
     { label: 'All', value: null },
@@ -124,34 +149,22 @@
     <div class="space-y-4">
       {#each data.flags as flag (flag.id)}
         {@const match = data.matchesById[flag.matchId] ?? null}
+        {@const isCurrentSeason =
+          !!match &&
+          data.currentSeasonId != null &&
+          match.seasonId === data.currentSeasonId}
+        {@const statusMeta = STATUS_META[flag.status]}
+        {@const StatusIcon = statusMeta.icon}
         <Card data-testid="match-flag-card" data-flag-id={flag.id}>
           <CardHeader
             class="flex flex-row flex-wrap items-start justify-between gap-3 space-y-0"
           >
             <div class="space-y-1">
               <div class="flex flex-wrap items-center gap-2">
-                {#if flag.status === 'Open'}
-                  <span
-                    class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
-                  >
-                    <Flag class="mr-1 h-3 w-3" />
-                    Open
-                  </span>
-                {:else if flag.status === 'Resolved'}
-                  <span
-                    class="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200"
-                  >
-                    <CheckCircle class="mr-1 h-3 w-3" />
-                    Resolved
-                  </span>
-                {:else}
-                  <span
-                    class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-                  >
-                    <XCircle class="mr-1 h-3 w-3" />
-                    Dismissed
-                  </span>
-                {/if}
+                <Badge variant="outline" class={statusMeta.class}>
+                  <StatusIcon class="mr-1 h-3 w-3" />
+                  {statusMeta.label}
+                </Badge>
                 <span class="text-sm text-muted-foreground">
                   Flagged by {flag.flaggedByDisplayName ?? 'Unknown'}
                   on {formatDate(flag.createdAt, '—', dateOpts)}
@@ -164,7 +177,7 @@
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={!match}
+                  disabled={!isCurrentSeason}
                   onclick={() => match && openEdit(match)}
                   data-testid="match-flag-edit"
                 >
@@ -181,8 +194,17 @@
                     type="submit"
                     size="sm"
                     variant="outline"
-                    disabled={!match}
+                    disabled={!isCurrentSeason}
                     data-testid="match-flag-recalculate"
+                    onclick={(event) => {
+                      if (
+                        !confirm(
+                          'Replay every match from this one to the end of the season?'
+                        )
+                      ) {
+                        event.preventDefault();
+                      }
+                    }}
                   >
                     <RefreshCw class="mr-1 h-3.5 w-3.5" />
                     Recalc
@@ -209,6 +231,13 @@
               >
                 This match no longer exists — it may have been deleted.
               </div>
+            {/if}
+
+            {#if flag.status === 'Open' && match && !isCurrentSeason}
+              <p class="text-xs text-muted-foreground">
+                This match is in a past season, so it can't be edited or
+                recalculated — resolve or dismiss the flag instead.
+              </p>
             {/if}
 
             <div class="space-y-1 rounded-md border border-border p-3">

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/match-flags/+page.svelte
@@ -5,10 +5,20 @@
   import { Alert } from '$lib/components/ui/alert';
   import * as Dialog from '$lib/components/ui/dialog';
   import { Label } from '$lib/components/ui/label';
-  import * as Table from '$lib/components/ui/table';
-  import { Flag, CheckCircle, AlertCircle, XCircle } from 'lucide-svelte';
+  import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
+  import MatchCard from '$lib/components/match-card/match-card.svelte';
+  import EditMatchDialog from '$lib/components/admin/edit-match-dialog.svelte';
+  import {
+    Flag,
+    CheckCircle,
+    AlertCircle,
+    XCircle,
+    Pencil,
+    RefreshCw,
+  } from 'lucide-svelte';
   import { page } from '$app/stores';
   import { formatDate } from '$lib/utils';
+  import type { MatchResponse } from '$api3';
 
   let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -17,8 +27,14 @@
   let resolutionNote = $state('');
   let resolveStatus = $state('Resolved');
 
+  let editing = $state<MatchResponse | null>(null);
+  let editDialogOpen = $state(false);
+
   const selectedFlag = $derived(
     data.flags?.find((f: { id: string }) => f.id === selectedFlagId)
+  );
+  const selectedMatch = $derived(
+    selectedFlag ? (data.matchesById[selectedFlag.matchId] ?? null) : null
   );
 
   function handleResolve(flagId: string) {
@@ -28,9 +44,16 @@
     dialogOpen = true;
   }
 
-  function truncate(text: string, max: number): string {
-    return text.length > max ? text.slice(0, max) + '...' : text;
+  function openEdit(match: MatchResponse) {
+    editing = match;
+    editDialogOpen = true;
   }
+
+  const dateOpts = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  } as const;
 
   const statusTabs = [
     { label: 'All', value: null },
@@ -47,7 +70,9 @@
   <div>
     <h1 class="text-3xl font-bold tracking-tight">Flagged Matches</h1>
     <p class="text-muted-foreground">
-      Review and resolve match flags reported by users
+      Review the flagged match, correct it if needed, then resolve or dismiss
+      the flag. Editing a match leaves rating history untouched — recalculate to
+      flow the correction through to the leaderboard.
     </p>
   </div>
 
@@ -96,29 +121,15 @@
       </p>
     </div>
   {:else}
-    <div class="rounded-lg border border-border">
-      <Table.Root>
-        <Table.Header>
-          <Table.Row>
-            <Table.Head>Flagged By</Table.Head>
-            <Table.Head>Reason</Table.Head>
-            <Table.Head>Status</Table.Head>
-            <Table.Head>Date</Table.Head>
-            <Table.Head class="text-right">Actions</Table.Head>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          {#each data.flags as flag (flag.id)}
-            <Table.Row>
-              <Table.Cell class="whitespace-nowrap font-medium">
-                {flag.flaggedByDisplayName ?? 'Unknown'}
-              </Table.Cell>
-              <Table.Cell class="max-w-[300px]">
-                <span class="text-sm" title={flag.reason}>
-                  {truncate(flag.reason, 80)}
-                </span>
-              </Table.Cell>
-              <Table.Cell>
+    <div class="space-y-4">
+      {#each data.flags as flag (flag.id)}
+        {@const match = data.matchesById[flag.matchId] ?? null}
+        <Card data-testid="match-flag-card" data-flag-id={flag.id}>
+          <CardHeader
+            class="flex flex-row flex-wrap items-start justify-between gap-3 space-y-0"
+          >
+            <div class="space-y-1">
+              <div class="flex flex-wrap items-center gap-2">
                 {#if flag.status === 'Open'}
                   <span
                     class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
@@ -141,32 +152,91 @@
                     Dismissed
                   </span>
                 {/if}
-              </Table.Cell>
-              <Table.Cell class="whitespace-nowrap text-sm">
-                {formatDate(flag.createdAt, '—', {
-                  year: 'numeric',
-                  month: 'short',
-                  day: 'numeric',
-                })}
-              </Table.Cell>
-              <Table.Cell class="text-right">
-                {#if flag.status === 'Open'}
-                  <Button size="sm" onclick={() => handleResolve(flag.id)}>
-                    <CheckCircle class="mr-1 h-3.5 w-3.5" />
-                    Resolve
+                <span class="text-sm text-muted-foreground">
+                  Flagged by {flag.flaggedByDisplayName ?? 'Unknown'}
+                  on {formatDate(flag.createdAt, '—', dateOpts)}
+                </span>
+              </div>
+            </div>
+
+            {#if flag.status === 'Open'}
+              <div class="flex flex-wrap items-center justify-end gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!match}
+                  onclick={() => match && openEdit(match)}
+                  data-testid="match-flag-edit"
+                >
+                  <Pencil class="mr-1 h-3.5 w-3.5" />
+                  Edit match
+                </Button>
+                <form method="POST" action="?/recalculate" use:enhance>
+                  <input
+                    type="hidden"
+                    name="fromMatchId"
+                    value={flag.matchId}
+                  />
+                  <Button
+                    type="submit"
+                    size="sm"
+                    variant="outline"
+                    disabled={!match}
+                    data-testid="match-flag-recalculate"
+                  >
+                    <RefreshCw class="mr-1 h-3.5 w-3.5" />
+                    Recalc
                   </Button>
-                {:else}
-                  <span class="text-xs text-muted-foreground">
-                    {flag.resolvedByDisplayName
-                      ? `by ${flag.resolvedByDisplayName}`
-                      : ''}
-                  </span>
+                </form>
+                <Button
+                  size="sm"
+                  onclick={() => handleResolve(flag.id)}
+                  data-testid="match-flag-resolve"
+                >
+                  <CheckCircle class="mr-1 h-3.5 w-3.5" />
+                  Resolve
+                </Button>
+              </div>
+            {/if}
+          </CardHeader>
+
+          <CardContent class="space-y-3">
+            {#if match}
+              <MatchCard {match} showMmr />
+            {:else}
+              <div
+                class="rounded-md border border-dashed border-border p-4 text-center text-sm text-muted-foreground"
+              >
+                This match no longer exists — it may have been deleted.
+              </div>
+            {/if}
+
+            <div class="space-y-1 rounded-md border border-border p-3">
+              <span class="text-sm font-medium text-muted-foreground">
+                Reason
+              </span>
+              <p class="whitespace-pre-wrap text-sm">{flag.reason}</p>
+            </div>
+
+            {#if flag.status !== 'Open'}
+              <div class="text-sm text-muted-foreground">
+                <span>
+                  {flag.status === 'Resolved'
+                    ? 'Resolved'
+                    : 'Dismissed'}{flag.resolvedByDisplayName
+                    ? ` by ${flag.resolvedByDisplayName}`
+                    : ''}{flag.resolvedAt
+                    ? ` on ${formatDate(flag.resolvedAt, '—', dateOpts)}`
+                    : ''}
+                </span>
+                {#if flag.resolutionNote}
+                  <p class="mt-1 italic">“{flag.resolutionNote}”</p>
                 {/if}
-              </Table.Cell>
-            </Table.Row>
-          {/each}
-        </Table.Body>
-      </Table.Root>
+              </div>
+            {/if}
+          </CardContent>
+        </Card>
+      {/each}
     </div>
   {/if}
 </div>
@@ -182,6 +252,10 @@
 
     {#if selectedFlag}
       <div class="space-y-4 py-4">
+        {#if selectedMatch}
+          <MatchCard match={selectedMatch} />
+        {/if}
+
         <div class="space-y-2 rounded-lg border border-border p-3">
           <div class="flex items-center gap-2">
             <span class="text-sm font-medium text-muted-foreground"
@@ -279,3 +353,10 @@
     {/if}
   </Dialog.Content>
 </Dialog.Root>
+
+<EditMatchDialog
+  open={editDialogOpen}
+  onOpenChange={(value) => (editDialogOpen = value)}
+  match={editing}
+  leaguePlayers={data.players}
+/>


### PR DESCRIPTION
## Summary

Resolving a match flag means inspecting the match it's about and often correcting it — but the admin **Flagged Matches** page only listed flag metadata (who flagged it, the reason, status). A moderator couldn't see the match or fix it without leaving the page. This wires the match into the flag workflow.

- **Show the match inline.** The page load now fetches each flag's match (deduped across flags, tolerant of a deleted match → shows a "no longer exists" notice) and renders it with the existing `MatchCard`. The list moved from a bare table to a card per flag.
- **Edit the match in place.** Reuses the existing `EditMatchDialog` (the same one the matches admin page uses) via a new `?/edit` action, plus a per-flag **Recalc** action — so a moderator can correct scores/players and flow the fix to the leaderboard before resolving.
- **Resolve / dismiss** is unchanged, but the resolve dialog now also shows the match for context.

Open flags get **Edit / Recalc / Resolve** actions; resolved/dismissed flags stay visible read-only with their resolution note.

## Why frontend-only
The existing `getMatch` / `updateMatch` / `recalculate` endpoints already provide everything, so there's no API/DTO change and no client regeneration.

## Tests
Added `frontend/e2e/match-flags.spec.ts` and seeded two open flags in `scripts/seed-data.sql` (the committed seed is hand-maintained — its generator has already diverged from it). Verified green against the full stack:

```
✓ setup › apply seed and sign in
✓ match-flags › shows the flagged match inline with who flagged it and why
✓ match-flags › edits the flagged match from the flag, leaving rating history intact
✓ match-flags › resolves a flag after reviewing the match
4 passed
```

Also passes `npm run check` and `npm run lint`.

## Release
Includes a `frontend: minor` changeset.