### PR TITLE
docs: simplify AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ deployment-specific values via env vars or CLI args in scripts.
 
 Three-service matchmaking and rating system:
 
-- **Frontend**: SvelteKit 2 / Svelte 5 + TypeScript + TailwindCSS
-- **API**: ASP.NET Core 8 — business logic and data persistence
-- **MMR API**: Go 1.23 — MMR calculations and team balancing
+- **Frontend**: SvelteKit + Svelte 5 + TypeScript + TailwindCSS
+- **API**: ASP.NET Core — business logic and data persistence
+- **MMR API**: Go — MMR calculations and team balancing
 
 ## Development Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,9 @@ dotnet run --project local-dev/MMRProject.AppHost
 ```
 
 This launches the .NET Aspire dashboard (logs, traces, metrics and endpoint
-links) and injects every service's config — shared admin secret, Postgres
-connection string, MMR API base URL, frontend API base path — so no per-service
-`.env` wiring is required. One-time setup (prerequisites and Clerk keys for
-sign-in) is documented in [`local-dev/README.md`](local-dev/README.md).
+links) and injects every service's config, so no per-service `.env` wiring is
+required. One-time setup (prerequisites and Clerk keys for sign-in) is
+documented in [`local-dev/README.md`](local-dev/README.md).
 
 ### Running a single service
 
@@ -63,15 +62,14 @@ go run main.go           # MMR API on http://localhost:8080
 go test ./...            # all tests (single package: go test ./test/mmr)
 ```
 
-Migrations run automatically on API startup when `Migration:Enabled` is true.
 Regenerate the frontend API client (`npm run generate-api`) after any API change.
 
 ### Database
 
 The AppHost provisions PostgreSQL (persisted in a Docker volume) and the API
-applies EF Core migrations on startup, so the local database needs no manual
-setup — inspect or open a shell on it from the Postgres resource in the Aspire
-dashboard.
+applies EF Core migrations on startup when `Migration:Enabled` is true, so the
+local database needs no manual setup — inspect or open a shell on it from the
+Postgres resource in the Aspire dashboard.
 
 ```bash
 # Import production data into a target database

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,24 +2,23 @@
 
 ## Public repo
 
-This repository is public. Do not check in references to specific deployments
-or production data — including org/league slugs, tenant/subscription IDs,
-resource group names, server names, database names, admin usernames, real
-user emails, or anything that names a particular live environment. Use
-placeholders in docs and require deployment-specific values via env vars or
-CLI args in scripts.
+This repository is public. Do not check in references to specific deployments or
+production data — org/league slugs, tenant/subscription IDs, resource group,
+server or database names, admin usernames, real user emails, or anything that
+names a live environment. Use placeholders in docs and require
+deployment-specific values via env vars or CLI args in scripts.
 
 ## Project Overview
 
 Three-service matchmaking and rating system:
 
-- **Frontend**: SvelteKit 2 with Svelte 5 + TypeScript + TailwindCSS web application
-- **API**: ASP.NET Core 8 service handling business logic and data persistence
-- **MMR API**: Go 1.23 service for MMR calculations and team balancing
+- **Frontend**: SvelteKit 2 / Svelte 5 + TypeScript + TailwindCSS
+- **API**: ASP.NET Core 8 — business logic and data persistence
+- **MMR API**: Go 1.23 — MMR calculations and team balancing
 
 ## Development Commands
 
-### Local development (recommended): the Aspire AppHost
+### Recommended: the Aspire AppHost
 
 One command starts and wires the whole stack — PostgreSQL, the MMR API (Go), the
 API (ASP.NET Core) and the frontend (SvelteKit):
@@ -29,57 +28,50 @@ dotnet run --project local-dev/MMRProject.AppHost
 ```
 
 This launches the .NET Aspire dashboard (logs, traces, metrics and endpoint
-links for every service). The AppHost injects the shared admin secret, the
-Postgres connection string, the MMR API base URL and the frontend's API base
-path, so no per-service `.env` wiring is required. One-time setup (prerequisites
-and Clerk keys for sign-in) is documented in
-[`local-dev/README.md`](local-dev/README.md).
+links) and injects every service's config — shared admin secret, Postgres
+connection string, MMR API base URL, frontend API base path — so no per-service
+`.env` wiring is required. One-time setup (prerequisites and Clerk keys for
+sign-in) is documented in [`local-dev/README.md`](local-dev/README.md).
 
-### Advanced: running a single service
+### Running a single service
 
-The commands below run one service in isolation — useful for fast iteration on a
-single service. Outside the AppHost you must supply each service's configuration
-yourself (connection string, `ADMIN_SECRET`, Clerk issuer, …); see
-[Configuration](#configuration).
-
-#### Frontend (SvelteKit with Svelte 5)
+Useful for fast iteration on one service. Outside the AppHost you must supply
+that service's configuration yourself (see [Configuration](#configuration)).
 
 ```bash
-cd frontend
+# Frontend — cd frontend
 npm install
-npm run dev              # Start dev server on http://localhost:5173
-npm run build            # Production build
-npm run check            # Type checking with svelte-check
-npm run lint             # Lint with ESLint and Prettier
-npm run format           # Format code with Prettier
-npm run generate-api     # Generate TypeScript API client from http://localhost:8081/swagger/v1/swagger.json
+npm run dev              # dev server on http://localhost:5173
+npm run build            # production build
+npm run check            # type checking (svelte-check)
+npm run lint             # ESLint + Prettier
+npm run format           # Prettier
+npm run generate-api     # regenerate the TS API client from the API's swagger.json
 ```
 
-#### API (ASP.NET Core)
-
 ```bash
-cd api/MMRProject.Api
+# API — cd api/MMRProject.Api
 dotnet restore
-dotnet run               # Start API on http://localhost:8081
-dotnet build             # Build the project
-dotnet ef migrations add <MigrationName> -o Data/Migrations -c ApiDbContext  # Create migration
+dotnet run               # API on http://localhost:8081 (Swagger UI at /swagger)
+dotnet build
+dotnet ef migrations add <MigrationName> -o Data/Migrations -c ApiDbContext
 ```
-
-#### MMR API (Go)
 
 ```bash
-cd mmr-api
-go run main.go           # Start MMR API on http://localhost:8080
-go test ./...            # Run all tests
-go test ./test/mmr       # Run specific test package
+# MMR API — cd mmr-api
+go run main.go           # MMR API on http://localhost:8080
+go test ./...            # all tests (single package: go test ./test/mmr)
 ```
 
-### Database Management
+Migrations run automatically on API startup when `Migration:Enabled` is true.
+Regenerate the frontend API client (`npm run generate-api`) after any API change.
 
-The Aspire AppHost provisions PostgreSQL (persisted in a Docker volume) and the
-API applies EF Core migrations automatically on startup, so the local database
-needs no manual setup. Inspect or open a shell on it from the Postgres resource
-in the Aspire dashboard.
+### Database
+
+The AppHost provisions PostgreSQL (persisted in a Docker volume) and the API
+applies EF Core migrations on startup, so the local database needs no manual
+setup — inspect or open a shell on it from the Postgres resource in the Aspire
+dashboard.
 
 ```bash
 # Import production data into a target database
@@ -88,77 +80,47 @@ in the Aspire dashboard.
 
 ## Architecture
 
-### Authentication Flow
+### Authentication
 
-- Uses Clerk for authentication
-- Frontend: `hooks.server.ts` handles auth middleware with `svelte-clerk`
-- API: JWT bearer token validation configured in `Program.cs` via `builder.AddAuth()`
-- Protected routes in frontend under `routes/(authed)/`
-- User context resolved via `IUserContextResolver` in API
-- **RBAC**: Three-tier role hierarchy (User, Moderator, Owner)
-  - Role checks in `routes/admin/+layout.server.ts` redirect unauthenticated users to `/`
-  - Admin routes accessible to Moderator and Owner roles
-  - Role management page restricted to Owner role only
+- Clerk for auth; the API validates JWT bearer tokens (`Program.cs`, `builder.AddAuth()`).
+- Frontend: `hooks.server.ts` runs Clerk auth, auth guards and API-client injection into `event.locals`; protected routes live under `routes/(authed)/`.
+- API: the authenticated user is resolved from JWT claims via `IUserContextResolver`.
+- **RBAC** — three roles (User, Moderator, Owner): `routes/admin/+layout.server.ts` gates admin routes to Moderator/Owner; the role-management page is Owner-only.
 
-### Frontend Architecture
+### Frontend
 
-- **Svelte 5**: Uses modern Svelte 5 features (runes, snippets)
-- **API Client Generation**: TypeScript clients generated from API's OpenAPI spec using `openapi-generator-cli`
-- **API Client Creation**: `lib/server/api/apiClient.ts` creates typed API clients with automatic JWT token injection
-- **Route Structure**:
-  - `routes/(authed)/` - Protected routes requiring authentication with shared layout (navbar, queue indicator)
-  - `routes/admin/` - Admin panel routes (separate from authed group, uses dark mode)
-  - `routes/login/` - Login page
-- **Auth Hooks**: `hooks.server.ts` sequence handles Clerk auth, auth guards, and API client injection into `event.locals`
-- **UI Components**:
-  - Component library: `bits-ui` for headless components + custom styled components in `lib/components/ui/`
-  - Icons: `lucide-svelte` for all icons
-  - Styling: TailwindCSS with HSL color variables for theming
-  - Dark mode: Applied via `dark` class on root element (admin UI uses dark mode)
-  - Reusable components: Button, Card, Input, Label, Table, Badge, Alert, etc.
-  - Admin UI: Icon-based sidebar navigation, stat cards, professional dark theme
+- Svelte 5 runes and snippets; TailwindCSS with HSL color variables; dark mode via a `dark` class on the root element (used by the admin UI).
+- Headless components from `bits-ui` plus custom styled components in `lib/components/ui/`; icons from `lucide-svelte`.
+- Typed API clients generated from the API's OpenAPI spec (`openapi-generator-cli`); created in `lib/server/api/apiClient.ts` with automatic JWT injection.
+- Routes: `(authed)/` (shared layout — navbar, queue indicator), `admin/` (separate group, dark mode), `login/`.
 
-### API Architecture
+### API
 
-- **Service Layer Pattern**: Controllers delegate to services (e.g., `IMatchMakingService`, `ISeasonService`)
-- **DbContext**: Entity Framework Core with `ApiDbContext` for PostgreSQL
-- **Background Services**: `MatchMakingBackgroundService` runs matchmaking asynchronously
-- **External API Integration**: Communicates with MMR API via `IMMRCalculationApiClient` with API key authentication
-- **User Context**: `IUserContextResolver` extracts authenticated user from JWT claims
-- **Soft Deletes**: Query filters on `DeletedAt` column applied globally in `ApiDbContext.OnModelCreating`
+- Service-layer pattern: controllers delegate to services (e.g. `IMatchMakingService`, `ISeasonService`).
+- EF Core `ApiDbContext` over PostgreSQL; global soft-delete query filters on `DeletedAt`.
+- `MatchMakingBackgroundService` runs matchmaking asynchronously.
+- Calls the MMR API via `IMMRCalculationApiClient` (API-key auth).
 
-### MMR API Architecture
+### MMR API
 
-- **Gin Framework**: HTTP routing and middleware
-- **OpenSkill Integration**: Uses `go-openskill` library for MMR calculations
-- **Custom MMR**: Custom MMR calculation implementations in `mmrCustom/`
-- **Environment Config**: Loaded via `config.LoadEnv()` from `.env` file
-- **Admin Secret**: API key authentication via `ADMIN_SECRET` environment variable
+- Gin HTTP framework; MMR via the `go-openskill` library plus custom logic in `mmrCustom/`.
+- Config loaded from `.env` (`config.LoadEnv()`); API-key auth via `ADMIN_SECRET`.
 
 ### Data Model
 
-Core entities in `api/MMRProject.Api/Data/Entities/`:
-
-- **Player**: User profile with MMR (mu, sigma, mmr), linked to Clerk via `IdentityUserId`
-- **Season**: Time-based divisions for matches
-- **Match**: Game record with two teams and season
-- **Team**: Two players with score and winner flag
-- **PlayerHistory**: Historical MMR snapshots per match
-- **MmrCalculation**: MMR deltas for each player in a match
-- **QueuedPlayer**: Matchmaking queue
-- **ActiveMatch**: In-progress matches
-- **PendingMatch**: Matches waiting to start
-- **PersonalAccessToken**: API tokens for external integrations
+Core entities in `api/MMRProject.Api/Data/Entities/`: **Player** (profile + MMR
+mu/sigma/mmr, linked to Clerk via `IdentityUserId`), **Season**, **Match** (two
+teams + season), **Team** (two players, score, winner flag), **PlayerHistory**
+(MMR snapshots per match), **MmrCalculation** (per-player MMR deltas),
+**QueuedPlayer**, **ActiveMatch**, **PendingMatch**, **PersonalAccessToken**.
 
 ## Configuration
 
-> In the recommended Aspire flow the AppHost injects all of the values below
-> (connection string, shared admin secret, MMR API base URL, frontend API base
-> path) — the only thing you set yourself is Clerk keys, via AppHost
-> user-secrets (see [`local-dev/README.md`](local-dev/README.md)). The sections
-> below document the configuration each service reads when run standalone.
+The AppHost injects everything below except Clerk keys (set those via AppHost
+user-secrets — see [`local-dev/README.md`](local-dev/README.md)). These values
+only matter when running a service standalone.
 
-### Frontend (.env)
+**Frontend (`.env`)**
 
 ```
 PUBLIC_CLERK_PUBLISHABLE_KEY=<clerk_publishable_key>
@@ -166,36 +128,28 @@ CLERK_SECRET_KEY=<clerk_secret_key>
 API_BASE_PATH=http://localhost:8081
 ```
 
-### API (appsettings.Development.json)
+**API (`appsettings.Development.json`)**
 
 ```json
 {
   "ConnectionStrings": {
     "ApiDbContext": "Host=localhost;Database=mmr_project;Username=postgres;Password=<password>"
   },
-  "Admin": {
-    "Secret": "<admin_secret>"
-  },
-  "Migration": {
-    "Enabled": true
-  },
-  "MMRCalculationAPI": {
-    "BaseUrl": "http://localhost:8080",
-    "ApiKey": "<mmr_api_key>"
-  }
+  "Admin": { "Secret": "<admin_secret>" },
+  "Migration": { "Enabled": true },
+  "MMRCalculationAPI": { "BaseUrl": "http://localhost:8080", "ApiKey": "<mmr_api_key>" }
 }
 ```
 
-### API User Secrets (Required)
+**API user-secret (required)** — the Clerk issuer URL (Clerk Dashboard → API
+Keys, e.g. `https://your-app.clerk.accounts.dev`):
 
 ```bash
 cd api/MMRProject.Api
 dotnet user-secrets set "Authorization:Issuer" "<clerk_issuer_url>"
 ```
 
-The Clerk issuer URL is found in Clerk Dashboard under API Keys (e.g., `https://your-app.clerk.accounts.dev`)
-
-### MMR API (.env)
+**MMR API (`.env`)**
 
 ```
 ADMIN_SECRET=<admin_secret>
@@ -203,22 +157,27 @@ ADMIN_SECRET=<admin_secret>
 
 ## Testing
 
-- **API**: Bruno collection in `api-collection/` for API testing
-- **MMR API**: Go tests in `mmr-api/test/` organized by package (api, custom, mmr, openskill)
-- **Frontend**: Component testing with Vitest (configured but not extensively used)
+- **API**: Bruno collection in `api-collection/`.
+- **MMR API**: Go tests in `mmr-api/test/` (packages: api, custom, mmr, openskill).
+- **Frontend**: Vitest (configured, lightly used).
 
 ## Deployment
 
-Releases are managed through lightweight changeset files in `.changeset/`. Feature PRs include a changeset markdown file specifying component bump types, and merging to main triggers an automated release PR. Merging the release PR creates per-component GitHub Releases. Deployment to Azure Container Apps is manual via the `Deploy Release` workflow, selecting a component and version from an existing GitHub Release tag.
+Releases use changeset files in `.changeset/`. A feature PR includes a changeset
+specifying per-component bump types; merging to main opens an automated release
+PR, and merging that PR creates per-component GitHub Releases. Deployment to
+Azure Container Apps is manual via the `Deploy Release` workflow (pick a
+component and version from an existing GitHub Release tag).
 
-**Do not manually bump component versions.** The release PR workflow (`scripts/release/apply-changesets.mjs`) owns the `version` field in `frontend/package.json`, `api/package.json`, `mmr-api/package.json`, the `<Version>` element in `MMRProject.Api.csproj`, and the per-component `CHANGELOG.md` files. Add a `.changeset/*.md` describing the change and let the release PR compute the bump. Manual edits to these fields will be overwritten on the next release PR. (Editing entries under `dependencies` / `devDependencies` is unrelated and remains a manual operation.)
+**Do not manually bump component versions.** The release PR workflow
+(`scripts/release/apply-changesets.mjs`) owns the `version` field in each
+component's `package.json`, the `<Version>` in `MMRProject.Api.csproj`, and the
+per-component `CHANGELOG.md` files — manual edits are overwritten on the next
+release PR. Add a `.changeset/*.md` describing the change and let the release PR
+compute the bump. (Editing `dependencies` / `devDependencies` is unrelated and
+remains manual.)
 
-**Infra/test-only PRs** (seed fixtures, e2e specs, CI, internal scripts, docs that don't affect a deployed component) skip the changeset and apply the `no-release` label on the PR instead. The release PR workflow only fires when a changeset file exists, so omitting the changeset is the no-op path.
-
-## Important Notes
-
-- Migrations run automatically on API startup when `Migration:Enabled` is true
-- Swagger UI available at http://localhost:8081/swagger for API documentation
-- Frontend API clients must be regenerated after API changes using `npm run generate-api`
-- Local PostgreSQL is provisioned by the Aspire AppHost and persisted in a Docker volume
-- All services use environment-based configuration (appsettings.json, .env files, user-secrets); the Aspire AppHost supplies these locally
+**Infra/test-only PRs** (seed fixtures, e2e specs, CI, internal scripts, docs
+that don't affect a deployed component) skip the changeset and apply the
+`no-release` label instead — the release PR only fires when a changeset file
+exists.


### PR DESCRIPTION
## What

Simplify the project guide (`AGENTS.md`, surfaced to agents via the `CLAUDE.md` symlink) by removing duplication and tightening prose. **No commands, config blocks, or rules were dropped** — this is a concision pass only.

## Changes

- Collapse the repeated "the AppHost injects all config" note — it appeared in the AppHost, Database, Configuration, and Important Notes sections — into a single statement under **Configuration**.
- Drop the standalone **Important Notes** section, folding its unique facts (migrations auto-run on startup, regenerate the API client after API changes, Swagger URL) into the sections they belong to.
- Tighten the **Architecture** and **Configuration** prose into scannable bullets while keeping every file-path pointer and env key.

Net: 224 → 183 lines, no behavioural or factual changes.

## Notes

- `no-release` (docs-only, no deployed component affected — no changeset).