### PR TITLE
test(frontend): fix leaderboard recent-match selector after date grouping

### DIFF
--- a/frontend/e2e/leaderboard.spec.ts
+++ b/frontend/e2e/leaderboard.spec.ts
@@ -29,7 +29,7 @@ test.describe('Leaderboard page', () => {
   }) => {
     await page.goto(LEAGUE_URL);
     const firstCard = page
-      .locator('.flex.flex-1.flex-col.items-stretch > div')
+      .locator('.flex.flex-1.flex-col.items-stretch > div.bg-card')
       .first();
 
     // The seed gives usernames `tuser` (test user), `alia`, `bobr`, etc.
@@ -69,7 +69,7 @@ test.describe('Leaderboard page', () => {
     await page.goto(LEAGUE_URL);
 
     const firstCard = page
-      .locator('.flex.flex-1.flex-col.items-stretch > div')
+      .locator('.flex.flex-1.flex-col.items-stretch > div.bg-card')
       .first();
     // MMR off by default — no "(+...)" delta text yet.
     await expect(


### PR DESCRIPTION
## Summary

`e2e/leaderboard.spec.ts` has a pre-existing failure on `main`: **"toggling MMR shows the (+/−delta) inline next to each player"** times out.

Root cause: the **"group recent matches by date" (#332)** change inserts date-header `<div>`s as direct children of the recent-matches container:

```svelte
<div class="flex flex-1 flex-col items-stretch gap-2">
  {#each recentMatchGroups as group}
    {#if group.label}<div class="…uppercase text-muted-foreground">{group.label}</div>{/if}
    <MatchCard match={group.match} showMmr={$showMmr} />
```

The test's `'.items-stretch > div'.first()` now selects that **date header** instead of the first match card, so the MMR delta span is never found. The same stale selector also made **"shows username … not display name"** pass *vacuously* (a date header trivially lacks display names).

## Fix

Scope the selector to the match card — `MatchCard`'s `Card.Root` carries `bg-card` — so both tests assert against an actual match card again:

```diff
-      .locator('.flex.flex-1.flex-col.items-stretch > div')
+      .locator('.flex.flex-1.flex-col.items-stretch > div.bg-card')
```

The component (`MmrDelta`, `MatchCard`, the `#show-mmr` toggle) is unchanged — this is a test-only fix.

## Verification

`npx playwright test e2e/leaderboard.spec.ts` → **9 passed** (was 8 passed / 1 failed). The previously-failing `:66` now runs in ~0.7s instead of the 11s timeout.

## Release

Test-only change — no changeset; `no-release` label applied.