### PR TITLE
feat(frontend): group admin matches list by date

### DIFF
--- a/.changeset/admin-matches-date-grouping.md
+++ b/.changeset/admin-matches-date-grouping.md
@@ -1,0 +1,6 @@
+---
+"frontend": minor
+---
+
+Group the admin matches list under date headers, matching the player-facing
+recent-matches and profile views. Grouping is per page (the list paginates).

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -84,6 +84,17 @@ test.describe('League admin', () => {
     await expect(page.getByText('Latest', { exact: true })).toBeVisible();
   });
 
+  test('matches page groups matches under date headers', async ({ page }) => {
+    await page.goto(`${LEAGUE_ADMIN}/matches`);
+    // Rows stay individually addressable (headers are separate divs).
+    await expect(page.getByTestId('admin-match-row')).toHaveCount(25);
+    // The seed's matches predate "today", so the first page renders at least
+    // one date header above its match rows.
+    await expect(
+      page.getByTestId('admin-match-date-header').first()
+    ).toBeVisible();
+  });
+
   test('edit dialog pre-fills the chosen match', async ({ page }) => {
     await page.goto(`${LEAGUE_ADMIN}/matches`);
     const firstEditButton = page

--- a/frontend/src/lib/components/match-card/match-date-header.svelte
+++ b/frontend/src/lib/components/match-card/match-date-header.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  interface Props extends HTMLAttributes<HTMLDivElement> {
+    label: string;
+  }
+
+  let { label, ...rest }: Props = $props();
+</script>
+
+<div
+  class="px-2 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+  {...rest}
+>
+  {label}
+</div>

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Leaderboard from '$lib/components/leaderboard/leaderboard.svelte';
   import MatchCard from '$lib/components/match-card/match-card.svelte';
+  import MatchDateHeader from '$lib/components/match-card/match-date-header.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
   import ReportMatchModal from '$lib/components/report-match-modal.svelte';
   import SeasonPicker from '$lib/components/season-picker.svelte';
@@ -119,11 +120,7 @@
   <div class="flex flex-1 flex-col items-stretch gap-2">
     {#each recentMatchGroups as group (group.match.id)}
       {#if group.label}
-        <div
-          class="px-2 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
-        >
-          {group.label}
-        </div>
+        <MatchDateHeader label={group.label} />
       {/if}
       <MatchCard match={group.match} showMmr={$showMmr} />
     {/each}

--- a/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/[orgSlug]/[leagueSlug]/player/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Kpi from '$lib/components/kpi.svelte';
   import MatchCard from '$lib/components/match-card/match-card.svelte';
+  import MatchDateHeader from '$lib/components/match-card/match-date-header.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
   import SeasonPicker from '$lib/components/season-picker.svelte';
   import { Alert } from '$lib/components/ui/alert';
@@ -326,11 +327,7 @@
         {/if}
         {#each matchGroups as group (group.match.id)}
           {#if group.label}
-            <div
-              class="px-2 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
-            >
-              {group.label}
-            </div>
+            <MatchDateHeader label={group.label} />
           {/if}
           {@const existingFlag = myFlagForMatch(group.match.id)}
           <div class="rounded-lg {existingFlag ? 'ring-1 ring-red-400' : ''}">

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.server.ts
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.server.ts
@@ -33,6 +33,8 @@ export const load: PageServerLoad = async ({
     offset,
     hasMore,
     latestMatchId: offset === 0 ? (trimmed[0]?.id ?? null) : null,
+    // Pin "now" server-side so date grouping is stable across SSR/hydration.
+    now: Date.now(),
   };
 };
 

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.svelte
@@ -2,6 +2,7 @@
   import { enhance } from '$app/forms';
   import EditMatchDialog from '$lib/components/admin/edit-match-dialog.svelte';
   import MatchCard from '$lib/components/match-card/match-card.svelte';
+  import MatchDateHeader from '$lib/components/match-card/match-date-header.svelte';
   import { Alert } from '$lib/components/ui/alert';
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
@@ -92,12 +93,10 @@
             {@const match = group.match}
             {@const isLatest = match.id === data.latestMatchId}
             {#if group.label}
-              <div
+              <MatchDateHeader
+                label={group.label}
                 data-testid="admin-match-date-header"
-                class="px-1 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
-              >
-                {group.label}
-              </div>
+              />
             {/if}
             <div
               class="flex flex-col gap-3 md:flex-row md:items-center"

--- a/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.svelte
+++ b/frontend/src/routes/admin/[orgSlug]/leagues/[leagueSlug]/matches/+page.svelte
@@ -19,6 +19,7 @@
     RefreshCw,
     Trash2,
   } from 'lucide-svelte';
+  import { groupMatchesByDate } from '$lib/utils';
   import type { MatchResponse } from '$api3';
   import type { ActionData, PageData } from './$types';
 
@@ -26,6 +27,10 @@
 
   const prevOffset = $derived(Math.max(0, data.offset - data.pageSize));
   const nextOffset = $derived(data.offset + data.pageSize);
+
+  // Group the current page's matches by date, mirroring the player-facing
+  // recent-matches and profile views. Grouping is per page (the list paginates).
+  const matchGroups = $derived(groupMatchesByDate(data.matches, data.now));
 
   let editing = $state<MatchResponse | null>(null);
   let editDialogOpen = $state(false);
@@ -83,8 +88,17 @@
         </p>
       {:else}
         <div class="flex flex-col gap-3">
-          {#each data.matches as match (match.id)}
+          {#each matchGroups as group (group.match.id)}
+            {@const match = group.match}
             {@const isLatest = match.id === data.latestMatchId}
+            {#if group.label}
+              <div
+                data-testid="admin-match-date-header"
+                class="px-1 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+              >
+                {group.label}
+              </div>
+            {/if}
             <div
               class="flex flex-col gap-3 md:flex-row md:items-center"
               data-testid="admin-match-row"


### PR DESCRIPTION
## Summary

The player-facing recent-matches and player-profile views group matches under date headers (#332), but the **admin matches page was still a flat list**. This brings the same date grouping to the admin side.

- Renders the current page's matches under date-group headers using the shared `groupMatchesByDate()` helper (`$lib/utils`) — the same one the player views use.
- The list paginates (25/page), so grouping is **per page** by design.

## Implementation

- `+page.server.ts`: pin `now: Date.now()` server-side so grouping is stable across SSR/hydration (mirrors the player league load).
- `+page.svelte`: `groupMatchesByDate(data.matches, data.now)`, render a date header before the first row of each group, then the existing match row (with its edit/recalc/delete actions and `Latest` badge) unchanged.
- Date headers carry `data-testid="admin-match-date-header"`; match rows keep `data-testid="admin-match-row"`, so existing selectors are unaffected.

## Tests

Added an e2e test (`admin.spec.ts`) asserting headers render and rows stay individually addressable. Full `admin.spec.ts` verified green against the real stack:

```
✓ matches page paginates and labels the latest match
✓ matches page groups matches under date headers   ← new
✓ edit dialog pre-fills the chosen match
✓ edit closes dialog and recalc shows a success alert
13 passed
```

Also passes `npm run check` and `npm run lint`.

## Release

Includes a `frontend: minor` changeset.