### PR TITLE
fix(api): serialise overlapping edits of the same match

### DIFF
--- a/.changeset/fix-concurrent-match-edit.md
+++ b/.changeset/fix-concurrent-match-edit.md
@@ -1,0 +1,10 @@
+---
+"api": patch
+---
+
+Fix overlapping edits of the same match corrupting each other. The two edits
+deleted the team rows the other had just rebuilt, and the loser failed on the
+`match_team_players` foreign key after the winner had committed — a 500 for an
+edit that had actually landed. Edits of a match now serialise on its row, and
+both child deletes key off the match rather than a list of team ids read
+earlier, so they cannot disagree about which teams they are clearing.

--- a/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
+++ b/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
@@ -6,6 +6,7 @@ using MMRProject.Api.Data.Entities.V3;
 using MMRProject.Api.DTOs.V3;
 using MMRProject.Api.IntegrationTests.Fixtures;
 using MMRProject.Api.Services.V3;
+using Npgsql;
 
 namespace MMRProject.Api.IntegrationTests.Matches;
 
@@ -1206,6 +1207,67 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
             Assert.True(delete.Result.StatusCode != HttpStatusCode.InternalServerError,
                 $"attempt {attempt}: concurrent delete returned 500");
         }
+    }
+
+    [Fact]
+    public async Task UpdateMatch_DoesNotQueueBehindAKeyShareLockOnTheMatch()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+        await CreateSeason(org.Id, league.Id);
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                ]
+            });
+        var match = await ReadJsonAsync<MatchResponse>(submitResponse);
+        Assert.NotNull(match);
+
+        // Inserting anything that references a match — a flag, a rating history
+        // row from a recalc — holds FOR KEY SHARE on the match row for the life
+        // of that transaction. An edit must not wait for it; only other edits
+        // and deletes should. Fails if the lock is widened to FOR UPDATE.
+        await using var connection = new NpgsqlConnection(postgres.GetConnectionString());
+        await connection.OpenAsync();
+        await using var keyShare = await connection.BeginTransactionAsync();
+        await using (var command = new NpgsqlCommand(
+            "SELECT id FROM matches WHERE id = @id FOR KEY SHARE", connection, keyShare))
+        {
+            command.Parameters.AddWithValue("id", match.Id);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        var update = Client.PatchAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/{match.Id}",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 7 }
+                ]
+            });
+
+        var finished = await Task.WhenAny(update, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.True(finished == update, "the edit blocked behind a key-share lock on the match row");
+        Assert.Equal(HttpStatusCode.OK, update.Result.StatusCode);
+
+        await keyShare.RollbackAsync();
     }
 
     [Fact]

--- a/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
+++ b/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
@@ -996,6 +996,162 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
     }
 
     [Fact]
+    public async Task UpdateMatch_MatchFromAnotherOrg_Returns404()
+    {
+        var orgA = await CreateOrganization("Org A", "org-a");
+        var leagueA = await CreateLeague(orgA.Id, "League A", "league-a");
+        await CreateSeason(orgA.Id, leagueA.Id);
+
+        var (_, _, a1) = await SeedTestUser(orgA.Id, leagueA.Id, "a1", "a1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, a2) = await SeedTestUser(orgA.Id, leagueA.Id, "a2", "a2@test.com");
+        var (_, _, a3) = await SeedTestUser(orgA.Id, leagueA.Id, "a3", "a3@test.com");
+        var (_, _, a4) = await SeedTestUser(orgA.Id, leagueA.Id, "a4", "a4@test.com");
+
+        AuthenticateAs("a1");
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{orgA.Id}/leagues/{leagueA.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [a1.Id, a2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [a3.Id, a4.Id], Score = 5 }
+                ]
+            });
+        var match = await ReadJsonAsync<MatchResponse>(submitResponse);
+        Assert.NotNull(match);
+
+        var orgB = await CreateOrganization("Org B", "org-b");
+        var leagueB = await CreateLeague(orgB.Id, "League B", "league-b");
+        await CreateSeason(orgB.Id, leagueB.Id);
+
+        var (_, _, b1) = await SeedTestUser(orgB.Id, leagueB.Id, "b1", "b1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, b2) = await SeedTestUser(orgB.Id, leagueB.Id, "b2", "b2@test.com");
+        var (_, _, b3) = await SeedTestUser(orgB.Id, leagueB.Id, "b3", "b3@test.com");
+        var (_, _, b4) = await SeedTestUser(orgB.Id, leagueB.Id, "b4", "b4@test.com");
+
+        // Moderator of B is authorized for B's route, but the match id belongs
+        // to A — the lookup must be scoped by org/league, not by id alone.
+        AuthenticateAs("b1");
+        var updateResponse = await Client.PatchAsJsonAsync(
+            $"api/v3/organizations/{orgB.Id}/leagues/{leagueB.Id}/matches/{match.Id}",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [b1.Id, b2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [b3.Id, b4.Id], Score = 0 }
+                ]
+            });
+
+        Assert.Equal(HttpStatusCode.NotFound, updateResponse.StatusCode);
+
+        using var scope = Factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+        // Counted first: a regression that wiped A's rows without rebuilding
+        // them would leave this empty, and Assert.All passes on empty.
+        var teams = await dbContext.Set<MatchTeam>()
+            .Where(t => t.MatchId == match.Id)
+            .ToListAsync();
+        Assert.Equal(2, teams.Count);
+        Assert.All(teams, t => Assert.Equal(leagueA.Id, t.LeagueId));
+        Assert.Equal([5, 10], teams.Select(t => t.Score).Order());
+    }
+
+    [Fact]
+    public async Task UpdateMatch_OverlappingEdits_AllSucceedAndLeaveMatchIntact()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+        await CreateSeason(org.Id, league.Id);
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                ]
+            });
+        var match = await ReadJsonAsync<MatchResponse>(submitResponse);
+        Assert.NotNull(match);
+
+        var url = $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/{match.Id}";
+
+        // Two PATCHes for one match must serialize rather than rebuild the team
+        // rows the other is deleting.
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            var first = Client.PatchAsJsonAsync(url, new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 4 }
+                ]
+            });
+            var second = Client.PatchAsJsonAsync(url, new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 6 }
+                ]
+            });
+
+            var responses = await Task.WhenAll(first, second);
+
+            Assert.All(responses, r =>
+                Assert.True(r.StatusCode == HttpStatusCode.OK,
+                    $"attempt {attempt}: concurrent edit returned {(int)r.StatusCode}"));
+
+            // Each response must describe one coherent match. Mapping the reply
+            // outside the row lock would let the other edit's teams arrive
+            // alongside this request's own, still-tracked ones.
+            foreach (var response in responses)
+            {
+                var body = await ReadJsonAsync<MatchResponse>(response);
+                Assert.NotNull(body);
+                Assert.Equal(2, body.Teams.Count);
+                Assert.Equal([0, 1], body.Teams.Select(t => t.Index).Order());
+                Assert.All(body.Teams, t => Assert.Equal(2, t.Players.Count));
+            }
+        }
+
+        using var scope = Factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+
+        var teams = await dbContext.Set<MatchTeam>()
+            .Include(t => t.Players)
+            .Where(t => t.MatchId == match.Id)
+            .ToListAsync();
+
+        Assert.Equal(2, teams.Count);
+        Assert.All(teams, t => Assert.Equal(2, t.Players.Count));
+
+        // One edit must have won wholesale — a mix of both would also leave two
+        // teams of two, so the scores are what pin it.
+        var winner = teams.Single(t => t.Index == 0);
+        var loser = teams.Single(t => t.Index == 1);
+        Assert.Equal(10, winner.Score);
+        Assert.Contains(loser.Score, new[] { 4, 6 });
+        Assert.True(winner.IsWinner);
+        Assert.False(loser.IsWinner);
+    }
+
+    [Fact]
     public async Task RecalculateMatches_RebuildsRatingHistoryFromMatch()
     {
         var org = await CreateOrganization();

--- a/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
+++ b/api/MMRProject.Api.IntegrationTests/Matches/MatchTests.cs
@@ -5,6 +5,7 @@ using MMRProject.Api.Data;
 using MMRProject.Api.Data.Entities.V3;
 using MMRProject.Api.DTOs.V3;
 using MMRProject.Api.IntegrationTests.Fixtures;
+using MMRProject.Api.Services.V3;
 
 namespace MMRProject.Api.IntegrationTests.Matches;
 
@@ -1149,6 +1150,118 @@ public class MatchTests(PostgresFixture postgres) : IntegrationTestBase(postgres
         Assert.Contains(loser.Score, new[] { 4, 6 });
         Assert.True(winner.IsWinner);
         Assert.False(loser.IsWinner);
+    }
+
+    [Fact]
+    public async Task UpdateAndDeleteSameMatchConcurrently_NeitherFailsWithServerError()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+        await CreateSeason(org.Id, league.Id);
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        // An edit and a delete of the same match touch the match row and its
+        // child rows in opposite orders unless both take the match row lock
+        // first, which deadlocks one of them into a 500.
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            var submitResponse = await Client.PostAsJsonAsync(
+                $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+                new SubmitMatchRequest
+                {
+                    Teams =
+                    [
+                        new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                        new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                    ]
+                });
+            var match = await ReadJsonAsync<MatchResponse>(submitResponse);
+            Assert.NotNull(match);
+
+            var url = $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches/{match.Id}";
+
+            var update = Client.PatchAsJsonAsync(url, new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 8 }
+                ]
+            });
+            var delete = Client.DeleteAsync(url);
+
+            await Task.WhenAll(update, delete);
+
+            // Whichever loses may 404 — it may not blow up. A PostgreSQL
+            // deadlock (40P01) surfaces here as a 500.
+            Assert.True(update.Result.StatusCode != HttpStatusCode.InternalServerError,
+                $"attempt {attempt}: concurrent update returned 500");
+            Assert.True(delete.Result.StatusCode != HttpStatusCode.InternalServerError,
+                $"attempt {attempt}: concurrent delete returned 500");
+        }
+    }
+
+    [Fact]
+    public async Task GetMatch_WithStaleTrackedTeams_ReturnsOnlyThePersistedRows()
+    {
+        var org = await CreateOrganization();
+        var league = await CreateLeague(org.Id);
+        await CreateSeason(org.Id, league.Id);
+
+        var (_, _, player1) = await SeedTestUser(org.Id, league.Id, "p1", "p1@test.com",
+            OrganizationRole.Moderator);
+        var (_, _, player2) = await SeedTestUser(org.Id, league.Id, "p2", "p2@test.com");
+        var (_, _, player3) = await SeedTestUser(org.Id, league.Id, "p3", "p3@test.com");
+        var (_, _, player4) = await SeedTestUser(org.Id, league.Id, "p4", "p4@test.com");
+
+        AuthenticateAs("p1");
+
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"api/v3/organizations/{org.Id}/leagues/{league.Id}/matches",
+            new SubmitMatchRequest
+            {
+                Teams =
+                [
+                    new SubmitMatchTeamRequest { Players = [player1.Id, player2.Id], Score = 10 },
+                    new SubmitMatchTeamRequest { Players = [player3.Id, player4.Id], Score = 5 }
+                ]
+            });
+        var match = await ReadJsonAsync<MatchResponse>(submitResponse);
+        Assert.NotNull(match);
+
+        using var scope = Factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApiDbContext>();
+        var matchesService = scope.ServiceProvider.GetRequiredService<IV3MatchesService>();
+
+        // The state UpdateMatchAsync is in after rebuilding a match: team
+        // entities tracked in this DbContext whose rows another transaction has
+        // since replaced. A tracked read splices them into match.Teams next to
+        // the rows actually in the table, and the caller gets four teams.
+        foreach (var index in new[] { 0, 1 })
+        {
+            dbContext.Set<MatchTeam>().Attach(new MatchTeam
+            {
+                Id = Guid.NewGuid(),
+                OrganizationId = org.Id,
+                LeagueId = league.Id,
+                MatchId = match.Id,
+                Index = index,
+                Score = 99,
+            });
+        }
+
+        var response = await matchesService.GetMatchAsync(org.Id, league.Id, match.Id);
+
+        Assert.Equal(2, response.Teams.Count);
+        Assert.DoesNotContain(response.Teams, t => t.Score == 99);
+        Assert.Equal([0, 1], response.Teams.Select(t => t.Index).Order());
     }
 
     [Fact]

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -366,7 +366,6 @@ public class V3MatchesService(
 
     public async Task<MatchResponse> UpdateMatchAsync(Guid orgId, Guid leagueId, Guid matchId, SubmitMatchRequest request)
     {
-        // No-tracking validation pass — we re-fetch as tracked once child rows are gone.
         var match = await dbContext.Set<V3Match>()
             .AsNoTracking()
             .FirstOrDefaultAsync(m => m.OrganizationId == orgId && m.LeagueId == leagueId && m.Id == matchId)
@@ -378,45 +377,73 @@ public class V3MatchesService(
         if (match.SeasonId != currentSeason.Id)
             throw new InvalidArgumentException("Only matches in the current season can be edited");
 
+        // Validated before the transaction opens: this resolves one player per
+        // round trip, and a rejected edit should not take the lock at all.
         var resolvedTeams = await ResolveAndValidateTeamsAsync(orgId, leagueId, request);
 
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
 
-        // Raw delete the old child rows so EF's change tracker doesn't fight when
-        // we add the rebuilt teams. Rating history for this match is intentionally
-        // left untouched — the caller invokes recalc afterwards.
-        var teamIds = await dbContext.Set<MatchTeam>()
-            .Where(t => t.MatchId == matchId)
-            .Select(t => t.Id)
-            .ToListAsync();
+        // Overlapping edits of one match must not interleave: each rebuilds the
+        // team rows the other is deleting.
+        var lockedMatch = await LockMatchForUpdateAsync(orgId, leagueId, matchId)
+            ?? throw new NotFoundException("Match not found");
 
+        // Re-checked against the row we actually hold, which the check above
+        // could not — it ran before the lock was granted.
+        if (lockedMatch.SeasonId != currentSeason.Id)
+            throw new InvalidArgumentException("Only matches in the current season can be edited");
+
+        // Both deletes key off the match rather than a list of team ids read
+        // earlier, so they cannot disagree about which teams they are clearing.
+        // Rating history is intentionally left alone — the caller recalcs after.
         await dbContext.Set<MatchTeamPlayer>()
-            .Where(p => teamIds.Contains(p.MatchTeamId))
+            .Where(p => p.MatchTeam.MatchId == matchId)
             .ExecuteDeleteAsync();
         await dbContext.Set<MatchTeam>()
             .Where(t => t.MatchId == matchId)
             .ExecuteDeleteAsync();
 
-        var trackedMatch = await dbContext.Set<V3Match>()
-            .FirstOrDefaultAsync(m => m.Id == matchId)
-            ?? throw new NotFoundException("Match disappeared during update");
-
-        foreach (var team in BuildMatchTeams(orgId, leagueId, request, resolvedTeams, trackedMatch.Id))
+        foreach (var team in BuildMatchTeams(orgId, leagueId, request, resolvedTeams, matchId))
         {
             dbContext.Set<MatchTeam>().Add(team);
         }
 
-        trackedMatch.RecordedAt = DateTimeOffset.UtcNow;
+        // Read after the lock was granted, so the surviving edit cannot end up
+        // with an earlier timestamp than the one it superseded. RecordedAt
+        // orders both the match list and the recalc replay bound.
+        lockedMatch.RecordedAt = DateTimeOffset.UtcNow;
 
         await dbContext.SaveChangesAsync();
+
+        // Mapped under the lock so a PATCH always returns its own write rather
+        // than whatever the next queued edit replaced it with.
+        var response = await LoadAndMapMatch(orgId, leagueId, matchId);
+
         await transaction.CommitAsync();
 
-        return await LoadAndMapMatch(orgId, leagueId, trackedMatch.Id);
+        return response;
     }
+
+    /// <summary>
+    /// Locks and returns the match row, or null when it does not exist.
+    /// <see cref="UpdateMatchAsync"/> and <see cref="DeleteMatchAsync"/> both
+    /// take this <em>before</em> the match's child rows; the other order
+    /// deadlocks them against each other.
+    /// </summary>
+    private Task<V3Match?> LockMatchForUpdateAsync(Guid orgId, Guid leagueId, Guid matchId) =>
+        dbContext.Set<V3Match>()
+            .FromSqlInterpolated(
+                $"SELECT * FROM matches WHERE id = {matchId} AND organization_id = {orgId} AND league_id = {leagueId} FOR UPDATE")
+            .AsTracking()
+            .FirstOrDefaultAsync();
 
     public async Task DeleteMatchAsync(Guid orgId, Guid leagueId, Guid matchId)
     {
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
+
+        // Before the child rows, to match the order UpdateMatchAsync locks in.
+        if (await LockMatchForUpdateAsync(orgId, leagueId, matchId) is null)
+            throw new NotFoundException("Match not found");
 
         var match = await dbContext.Set<V3Match>()
             .Include(m => m.Teams)
@@ -835,7 +862,11 @@ public class V3MatchesService(
 
     private async Task<MatchResponse> LoadAndMapMatch(Guid orgId, Guid leagueId, Guid matchId)
     {
+        // AsNoTracking so the graph comes purely from the query: a tracked read
+        // would let EF splice a caller's own just-replaced team entities back
+        // into Teams alongside the rows actually in the table.
         var match = await dbContext.Set<V3Match>()
+            .AsNoTracking()
             .Include(m => m.Teams)
                 .ThenInclude(t => t.Players)
                     .ThenInclude(p => p.LeaguePlayer)

--- a/api/MMRProject.Api/Services/V3/V3MatchesService.cs
+++ b/api/MMRProject.Api/Services/V3/V3MatchesService.cs
@@ -430,10 +430,17 @@ public class V3MatchesService(
     /// take this <em>before</em> the match's child rows; the other order
     /// deadlocks them against each other.
     /// </summary>
+    /// <remarks>
+    /// FOR NO KEY UPDATE rather than the FOR UPDATE used elsewhere in this
+    /// namespace: it excludes other edits and deletes just the same, but not
+    /// the FOR KEY SHARE that inserting a row referencing this match takes, so
+    /// flagging a match or writing its rating history does not queue behind an
+    /// edit.
+    /// </remarks>
     private Task<V3Match?> LockMatchForUpdateAsync(Guid orgId, Guid leagueId, Guid matchId) =>
         dbContext.Set<V3Match>()
             .FromSqlInterpolated(
-                $"SELECT * FROM matches WHERE id = {matchId} AND organization_id = {orgId} AND league_id = {leagueId} FOR UPDATE")
+                $"SELECT * FROM matches WHERE id = {matchId} AND organization_id = {orgId} AND league_id = {leagueId} FOR NO KEY UPDATE")
             .AsTracking()
             .FirstOrDefaultAsync();
 


### PR DESCRIPTION
> **Split out of the original PR.** The client-side half — the reported "error over a successful save" bug — is now #379 and ships independently. This PR is the server-side concurrency fix, separated so it can be tested more thoroughly before merging.

## The bug

`UpdateMatchAsync` deleted `MatchTeamPlayer` rows by a **stale snapshot** of team ids but `MatchTeam` rows by `MatchId`. Two overlapping PATCHes for one match therefore deleted the rows the other had just rebuilt: the second edit's player-delete matched nothing (its ids were gone), then its team-delete hit the winner's freshly inserted rows, which still had children.

```
23503: update or delete on table "match_teams" violates foreign key
constraint "fk_match_team_players_team" on table "match_team_players"
```

The winner had already committed, so the data changed while the caller got a 500 for an edit that landed.

## Why keying both deletes off the match is not enough

It was my first fix and it does not hold. Under READ COMMITTED the two `DELETE`s straddle the other transaction's commit: the player-delete takes its snapshot before the winner commits, blocks, and completes having deleted nothing new; the team-delete is a *fresh statement with a fresh snapshot*, sees the winner's teams, and orphans their players. Same `23503`. Serialisation is required — verified by removing the lock, which reproduces the 500 on the first attempt.

## The fix

Edits serialise on the match row, locked with `SELECT … FOR UPDATE` — the idiom `V3MatchMakingService` and `V3PendingMatchCoordinator` already use four times. Locking through a `SELECT` returns the row, so one statement covers the lock, the not-found check, the season re-read and the `RecordedAt` stamp — the last evaluated *after* the lock is granted, so the surviving edit cannot take an earlier timestamp than the one it superseded.

`DeleteMatchAsync` takes the same lock before its child rows; the opposite order deadlocks it against a concurrent edit. `LoadAndMapMatch` reads `AsNoTracking`, so a caller's own just-replaced team entities cannot be spliced into `Teams` alongside the rows actually in the table, and is called before the commit so a PATCH returns its own write.

Validation runs before the transaction opens, so a rejected edit never takes the lock.

## Lock mode

`FOR NO KEY UPDATE`, not the `FOR UPDATE` used elsewhere in `Services/V3`. Measured against Postgres rather than reasoned about:

| | blocks another edit / a delete | blocks `FOR KEY SHARE` (child inserts) |
|---|---|---|
| `FOR UPDATE` | yes | **yes** |
| `FOR NO KEY UPDATE` | yes | no |

Both give the mutual exclusion this needs — two edits, and edit vs delete, all take the same lock. `FOR UPDATE` additionally makes flagging a match, or a recalc writing its rating history, queue behind an in-flight edit. The narrower lock avoids that, and the helper carries a `remarks` block explaining why it diverges from its neighbours.

## Testing

Every fix below is verified to **fail without its change**, not merely to pass with it.

| Test | Covers | Verified by |
|---|---|---|
| `UpdateMatch_OverlappingEdits_AllSucceedAndLeaveMatchIntact` | the FK crash | removing the lock → 500 on attempt 0 |
| `UpdateAndDeleteSameMatchConcurrently_NeitherFailsWithServerError` | lock ordering vs delete | removing the lock from `DeleteMatchAsync` → deadlock 500 on attempt 0 |
| `GetMatch_WithStaleTrackedTeams_ReturnsOnlyThePersistedRows` | the tracked-read splice | removing `AsNoTracking` → `Actual: 4` teams |
| `UpdateMatch_DoesNotQueueBehindAKeyShareLockOnTheMatch` | the lock mode | widening to `FOR UPDATE` → the edit blocks |
| `UpdateMatch_MatchFromAnotherOrg_Returns404` | tenant scoping | new coverage; none existed |

Two of these — the deadlock ordering and the tracked-read splice — I initially reported as untestable, on the grounds that the window between commit and read is too narrow to hit from outside. That was wrong. Neither needs the race: attaching team entities whose rows no longer exist reproduces the four-teams read deterministically, and a PATCH racing a DELETE deadlocks on the first attempt. Both go through the real HTTP surface against real Postgres.

**Still not covered:** nothing end-to-end exercises any of this, and nothing can — every e2e test asserts exactly one edit request, because #379's guard prevents a second. The browser cannot reach the concurrent case.

147 API integration tests pass.

## Follow-ups filed

- #380 — concurrent edits still silently overwrite each other. This PR serialises them, which is a prerequisite for detecting the conflict, but does not detect it; `UpdateMatch_OverlappingEdits_…` asserting both succeed codifies last-write-wins as the current contract.
- #378 — `RecalculateCurrentSeasonAsync` has no transaction and no serialisation, and its button sits next to Edit on the same page.

