### PR TITLE
test(frontend): player picker e2e coverage + AGENTS.md e2e guidance and trim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,38 @@ ADMIN_SECRET=<admin_secret>
 - **API**: Bruno collection in `api-collection/`.
 - **MMR API**: Go tests in `mmr-api/test/` (packages: api, custom, mmr, openskill).
 - **Frontend**: Vitest (configured, lightly used).
+- **End-to-end**: Playwright in `frontend/e2e/`, driving Chromium against the full
+  stack. See [`frontend/e2e/README.md`](frontend/e2e/README.md).
+
+### Run e2e before shipping a frontend change
+
+`e2e.yml` is `workflow_dispatch` only — it does **not** run on pull requests.
+`test-ui.yml` covers lint, Vitest, build and `svelte-check`, so an entirely green
+PR still says nothing about whether the app works. Verify any change under
+`frontend/src/` locally:
+
+```bash
+cd frontend && npm run e2e   # boots Postgres, both APIs and Vite on its own ports
+```
+
+- **Compare against the merge base.** Run the suite on `main` too, so a failure
+  you inherited isn't read as one you caused, or the reverse.
+- **Cover the behaviour you changed**, especially interaction state (focus,
+  keyboard, open/closed). Some components have no coverage at all, so "the suite
+  is green" can mean "nothing exercises this".
+- **Confirm a failure before believing it.** One seeded database, serial
+  execution — a flake and a real regression look identical on a single run.
+  Re-run with `--grep`, and check spec ordering before blaming another spec.
+- **`fill()` is not typing.** It sets the value and dispatches `input` — no
+  `keydown`, and no `focus` when the element already has it (the first submit
+  slot is `autofocus`). Use `pressSequentially()` when a component keys off
+  those events.
+
+From a worktree: copy the gitignored `frontend/.env`, `frontend/.env.e2e` and
+`mmr-api/.env` from your main checkout, and use a real `npm ci` — a symlinked
+`node_modules` resolves outside the worktree root, Vite's `server.fs.allow`
+blocks the client entry, and the app never hydrates. To run beside another e2e
+run, override `E2E_DB_NAME`, `E2E_MMR_API_PORT`, `E2E_API_PORT` and `E2E_PORT`.
 
 ## Deployment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,28 +37,16 @@ documented in [`local-dev/README.md`](local-dev/README.md).
 Useful for fast iteration on one service. Outside the AppHost you must supply
 that service's configuration yourself (see [Configuration](#configuration)).
 
-```bash
-# Frontend — cd frontend
-npm install
-npm run dev              # dev server on http://localhost:5173
-npm run build            # production build
-npm run check            # type checking (svelte-check)
-npm run lint             # ESLint + Prettier
-npm run format           # Prettier
-```
+Each service uses its standard toolchain — `npm run <script>` per
+`frontend/package.json`, `dotnet run`, `go run main.go`. Default ports: frontend
+5173, API 8081 (Swagger UI at `/swagger`), MMR API 8080.
+
+EF Core migrations are the one non-obvious invocation — the output directory and
+the context must both be passed explicitly:
 
 ```bash
-# API — cd api/MMRProject.Api
-dotnet restore
-dotnet run               # API on http://localhost:8081 (Swagger UI at /swagger)
-dotnet build
+cd api/MMRProject.Api
 dotnet ef migrations add <MigrationName> -o Data/Migrations -c ApiDbContext
-```
-
-```bash
-# MMR API — cd mmr-api
-go run main.go           # MMR API on http://localhost:8080
-go test ./...            # all tests (single package: go test ./test/mmr)
 ```
 
 The frontend's v3 API client (`frontend/src/api-v3`) is hand-maintained — update
@@ -106,11 +94,10 @@ Postgres resource in the Aspire dashboard.
 
 ### Data Model
 
-Core entities in `api/MMRProject.Api/Data/Entities/`: **Player** (profile + MMR
-mu/sigma/mmr, linked to Clerk via `IdentityUserId`), **Season**, **Match** (two
-teams + season), **Team** (two players, score, winner flag), **PlayerHistory**
-(MMR snapshots per match), **MmrCalculation** (per-player MMR deltas),
-**QueuedPlayer**, **ActiveMatch**, **PendingMatch**, **PersonalAccessToken**.
+Entities live in `api/MMRProject.Api/Data/Entities/`. The non-obvious parts:
+**Player** carries the OpenSkill `mu`/`sigma` pair alongside the derived `mmr`
+and links to Clerk via `IdentityUserId`; **PlayerHistory** and
+**MmrCalculation** are per-match snapshots and deltas, not live state.
 
 ## Configuration
 
@@ -118,13 +105,7 @@ The AppHost injects everything below except Clerk keys (set those via AppHost
 user-secrets — see [`local-dev/README.md`](local-dev/README.md)). These values
 only matter when running a service standalone.
 
-**Frontend (`.env`)**
-
-```
-PUBLIC_CLERK_PUBLISHABLE_KEY=<clerk_publishable_key>
-CLERK_SECRET_KEY=<clerk_secret_key>
-API_BASE_PATH=http://localhost:8081
-```
+**Frontend (`.env`)** — see `frontend/.env.example`.
 
 **API (`appsettings.Development.json`)**
 
@@ -147,11 +128,7 @@ cd api/MMRProject.Api
 dotnet user-secrets set "Authorization:Issuer" "<clerk_issuer_url>"
 ```
 
-**MMR API (`.env`)**
-
-```
-ADMIN_SECRET=<admin_secret>
-```
+**MMR API (`.env`)** — see `mmr-api/.env.example`.
 
 ## Testing
 

--- a/frontend/e2e/player-picker.spec.ts
+++ b/frontend/e2e/player-picker.spec.ts
@@ -1,0 +1,146 @@
+// Behaviour of the two player pickers:
+//   - submit/components/team-member-field.svelte  (match submission slots)
+//   - player/[id]/components/filter.svelte        (compare filter on a profile)
+//
+// The compare filter had no e2e coverage at all, and the submit picker was only
+// covered incidentally by the flows that use it to fill a match. These specs
+// pin the picker interactions themselves.
+import { test, expect, type Page } from '@playwright/test';
+
+// Fixture ids from scripts/seed-data.sql (Test League, team size 2).
+const TEST_LEAGUE_ID = '22222222-2222-2222-2222-222222222222';
+const TEST_USER_LEAGUE_PLAYER_ID = '66666666-6666-6666-6666-666666666601';
+const ALICE_LEAGUE_PLAYER_ID = 'bed02f01-6ea5-514a-9815-dbf9fdaacfa7';
+const BOB_LEAGUE_PLAYER_ID = 'f6a97f23-2a35-58c3-b1e0-6085c728ae2d';
+
+const SUBMIT_URL = '/test-org/test-league/submit';
+const PROFILE_URL = `/test-org/test-league/player/${TEST_USER_LEAGUE_PLAYER_ID}`;
+
+// The "You" slot is autofocused, so a keypress can land before SvelteKit has
+// hydrated and attached its handlers — the browser then applies its own default
+// (implicit form submission) and the test sees a phantom failure. Waiting for
+// the network to settle is a cheap gate that keeps these specs deterministic.
+const gotoHydrated = (page: Page, url: string) =>
+  page.goto(url, { waitUntil: 'networkidle' });
+
+// Suggestions render as PlayerButton, i.e. a <button> element. Matching the
+// element rather than an ARIA role keeps these specs stable if the picker's
+// listbox semantics change.
+const suggestion = (scope: Page, name: string | RegExp) =>
+  scope.locator('button', { hasText: name }).first();
+
+// The submit page reads its quick-pick list from localStorage, so seed it
+// before the page's hydration effect runs.
+async function seedRecentPlayers(page: Page, leaguePlayerIds: string[]) {
+  await page.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    [`latestLeaguePlayerIds:${TEST_LEAGUE_ID}`, leaguePlayerIds.join(',')]
+  );
+}
+
+test.describe('Submit — player slot picker', () => {
+  test('lists recent players for an empty slot without further interaction', async ({
+    page,
+  }) => {
+    await seedRecentPlayers(page, [
+      ALICE_LEAGUE_PLAYER_ID,
+      BOB_LEAGUE_PLAYER_ID,
+    ]);
+    await gotoHydrated(page, SUBMIT_URL);
+
+    const team1 = page.locator('#team1-step');
+    await expect(team1.locator('input[placeholder="Filter..."]')).toBeVisible();
+    await expect(team1.getByText('Recent players')).toBeVisible();
+    await expect(suggestion(page, 'Alice Anderson')).toBeVisible();
+  });
+
+  test('Enter with an empty filter does not pick a player', async ({
+    page,
+  }) => {
+    await seedRecentPlayers(page, [
+      ALICE_LEAGUE_PLAYER_ID,
+      BOB_LEAGUE_PLAYER_ID,
+    ]);
+    await gotoHydrated(page, SUBMIT_URL);
+
+    const team1 = page.locator('#team1-step');
+    // Team 1 renders one slot heading ("You") until a player is chosen; the
+    // teammate slot appearing is an unambiguous "a pick happened" signal.
+    await expect(team1.locator('h4')).toHaveCount(1);
+
+    const you = team1.locator('input[placeholder="Filter..."]').first();
+    await you.click();
+    // Clicking opens the suggestions; asserting that first also guarantees the
+    // page is interactive before the keypress below.
+    await expect(suggestion(page, 'Alice Anderson')).toBeVisible();
+
+    await you.press('Enter');
+
+    await expect(team1.locator('h4')).toHaveCount(1);
+    await expect(you).toBeVisible();
+  });
+
+  // Keyboard selection isn't implemented yet — today Enter in a filter falls
+  // through to the form. Kept as the executable spec for that behaviour so it
+  // can simply be un-skipped once the pickers support it.
+  test.fixme('typing a filter and pressing Enter picks the top match', async ({
+    page,
+  }) => {
+    await gotoHydrated(page, SUBMIT_URL);
+
+    const team1 = page.locator('#team1-step');
+    const you = team1.locator('input[placeholder="Filter..."]').first();
+    await you.click();
+    await you.pressSequentially('alia');
+    await expect(suggestion(page, 'Alice Anderson')).toBeVisible();
+
+    await you.press('Enter');
+
+    // The filled slot renders the chosen player, and the teammate slot appears.
+    await expect(team1.getByText('Alice Anderson')).toBeVisible();
+    await expect(team1.locator('h4')).toHaveCount(2);
+  });
+});
+
+test.describe('Player profile — compare filter', () => {
+  test('picking a player adds a chip and clears the input', async ({
+    page,
+  }) => {
+    await gotoHydrated(page, PROFILE_URL);
+
+    const input = page.locator('input[placeholder="Filter..."]').first();
+    await input.click();
+    await input.pressSequentially('alia');
+    await suggestion(page, 'Alice Anderson').click();
+
+    await expect(
+      page.locator('.bg-secondary', { hasText: 'Alice Anderson' })
+    ).toBeVisible();
+    // The filter is multi-select, so the box has to be ready for the next name.
+    await expect(input).toHaveValue('');
+  });
+
+  test('a player can be picked again after removing their chip', async ({
+    page,
+  }) => {
+    await gotoHydrated(page, PROFILE_URL);
+
+    const input = page.locator('input[placeholder="Filter..."]').first();
+    const chip = page.locator('.bg-secondary', { hasText: 'Alice Anderson' });
+
+    await input.click();
+    await input.pressSequentially('alia');
+    await suggestion(page, 'Alice Anderson').click();
+    await expect(chip).toBeVisible();
+
+    await chip.locator('button').click();
+    await expect(chip).toHaveCount(0);
+
+    await input.click();
+    await input.fill('');
+    await input.pressSequentially('alia');
+    await suggestion(page, 'Alice Anderson').click();
+
+    await expect(chip).toBeVisible();
+  });
+});


### PR DESCRIPTION
Three commits: e2e coverage for the player pickers, the AGENTS.md guidance that would have caught the gap earlier, and a trim of AGENTS.md content a session can derive from the repo itself.

## `frontend/e2e/player-picker.spec.ts`

The compare filter on a player profile (`player/[id]/components/filter.svelte`) had no e2e coverage at all, and the submit-page slot picker was only exercised incidentally by the flows that use it to fill in a match — so the picker interactions themselves were unpinned.

- submit: an empty slot lists recent players without further interaction
- submit: Enter with an empty filter does not pick a player
- compare filter: picking a player adds a chip and clears the input
- compare filter: a player can be picked again after removing their chip

Plus one `test.fixme`: `typing a filter and pressing Enter picks the top match` describes keyboard selection, which isn't implemented today — Enter in a filter currently falls through to the form. It's included as the executable spec for that behaviour so it can be un-skipped when the pickers grow it, rather than being re-derived later. #361 is the change that would make it pass.

## AGENTS.md — e2e guidance

The Testing section didn't mention e2e at all. Adds an end-to-end bullet and a short section on running the suite before shipping a frontend change:

- `e2e.yml` is `workflow_dispatch` only, so a fully green PR exercises lint, Vitest, build and `svelte-check` but never the app
- compare against the merge base, so an inherited failure isn't read as one you caused
- cover the interaction state you changed — some components have no coverage, so "green" can mean "nothing exercises this"
- confirm a failure before believing it: one seeded DB and serial execution make a flake and a regression look identical on a single run
- Playwright's `fill()` is not typing — no `keydown`, and no `focus` when the element already has it
- the worktree setup (gitignored env files, real `npm ci`) and the port/DB overrides for running two suites side by side

## AGENTS.md — trim

Content a session can reconstruct by reading the repo, so it costs context every session for nothing:

- the three single-service command blocks are `package.json` scripts and standard `dotnet`/`go` invocations — replaced by one line naming the toolchains and ports, keeping the EF migrations command, which genuinely needs `-o` and `-c` passed explicitly
- the Data Model entity list is an `ls` of `Data/Entities/`, and had already drifted out of date (missing `MatchFlag`, `MatchFlagStatus`, `PlayerRole`) — replaced by a pointer plus the parts the code doesn't announce
- the frontend and mmr-api `.env` blocks duplicated their `.env.example` files verbatim

Net across both AGENTS.md commits: +9 lines. The API `appsettings` block stays — `ConnectionStrings`, `Admin.Secret` and `Migration.Enabled` aren't in the committed `appsettings.json`, so it isn't derivable.

## Verification

Full suite on this branch: 80 passed, 1 skipped, 0 failed. The new specs create no data and don't mutate the seed, so they don't perturb the shared fixture.

`e2e.yml` doesn't run on PRs, so the checks here won't exercise any of this — it needs a manual dispatch or a local `npm run e2e`.

## Worth flagging in review

- `gotoHydrated()` uses `waitUntil: 'networkidle'`. The "You" slot is autofocused, so a keypress can land before SvelteKit hydrates and the browser applies its own default (implicit form submission), which shows up as a phantom failure. Happy to swap it for a narrower hydration signal if there's a preferred pattern.
- Fixture ids are hardcoded from `scripts/seed-data.sql`, following the existing convention in `profile.spec.ts`.

No changeset — test/docs only, labelled `no-release` per AGENTS.md.