### PR TITLE
docs(changeset): trim the badge entry and ask for concise descriptions

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -16,3 +16,34 @@ Description of the change.
 
 Valid components: `frontend`, `api`, `mmr-api`
 Valid bump types: `major`, `minor`, `patch`
+
+## Writing the description
+
+The description becomes a bullet in the component's `CHANGELOG.md` and in the
+GitHub Release, so write it for someone deciding whether a release affects
+them — not as a summary of the diff.
+
+**Keep it to one or two sentences.** Lead with what changed for the user, in
+the imperative ("Show admins…", "Hide not-yet-started seasons…"). Name a new
+endpoint or config flag if callers need to know about it. Leave out
+implementation detail, request ordering, file names, and rationale — the PR and
+the commits hold those.
+
+```markdown
+Show admins a red badge wherever match flags are waiting to be resolved, backed
+by a new `GET /api/v3/me/badges`.
+```
+
+Not:
+
+```markdown
+Surface unresolved match flags to admins with red badges across the nav. A new
+endpoint returns open-flag counts (total plus per-organization and per-league)
+for the organizations a user administers, so the account/settings control, the
+Admin menu item, the admin organization list, the org sidebar, the leagues list
+and the league sub-nav all show a count. The frontend fetches it alongside the
+existing profile load, replacing the previous per-league fan-out. …
+```
+
+A long entry also tends to drift: the more it describes *how* something works,
+the more likely it contradicts the code by the time it ships.

--- a/.changeset/admin-unresolved-flag-badges.md
+++ b/.changeset/admin-unresolved-flag-badges.md
@@ -3,4 +3,7 @@
 "api": minor
 ---
 
-Surface unresolved match flags to admins with red badges across the nav. A new `GET /api/v3/me/badges` endpoint returns open-flag counts (total plus per-organization and per-league) for the organizations a user administers, so the account/settings control, the Admin menu item, the admin organization list, the org sidebar, the leagues list, and the league sub-nav all show a count when there is something to handle. The frontend fetches it alongside the existing profile load, replacing the previous per-league flag fan-out. The flagged-matches filter now defaults to Open and moves All to the end.
+Show admins a red badge wherever match flags are waiting to be resolved — the
+account menu, the admin nav, and each affected organization and league — backed
+by a new `GET /api/v3/me/badges`. The flagged-matches filter now defaults to
+Open.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,11 @@ release PR. Add a `.changeset/*.md` describing the change and let the release PR
 compute the bump. (Editing `dependencies` / `devDependencies` is unrelated and
 remains manual.)
 
+**Keep changeset descriptions to one or two sentences.** They ship verbatim as
+`CHANGELOG.md` bullets and GitHub Release notes, so say what changed for the
+user and name any new endpoint or flag — don't recount the implementation. See
+[`.changeset/README.md`](.changeset/README.md) for examples.
+
 **Infra/test-only PRs** (seed fixtures, e2e specs, CI, internal scripts, docs
 that don't affect a deployed component) skip the changeset and apply the
 `no-release` label instead — the release PR only fires when a changeset file


### PR DESCRIPTION
## Why

The changeset for #348 ran four sentences and described the request ordering ("fetches it alongside the existing profile load"). A later review in that same PR changed the ordering — the call is now sequenced after the profile load, and skipped entirely for non-admins — so the text heading for `CHANGELOG.md` and the GitHub Release described the opposite of the shipped behaviour.

Release PR #347 has not merged yet, so correcting the changeset here regenerates it with the accurate entry.

## What

- **Trim the badge changeset** to two sentences: what an admin now sees, the new endpoint, and the filter default. 640 → 240 chars, no implementation detail left to drift.
- **Document the expectation** in `.changeset/README.md` — a "writing the description" section with a good/bad example, since that is the file you have open while writing one.
- **Point at it from `AGENTS.md`**, next to the existing changeset rules.

## Notes

- Validated with the repo's own `scripts/release/validate-changesets.mjs`.
- `changeset-check` treats a modified changeset as "changeset present" and validates it, so this PR must **not** carry the `no-release` label.
- Both `.changeset/README.md` and `AGENTS.md` already fail `prettier --check` on `main`, and neither is covered by the frontend lint run. I left the surrounding drift alone rather than bury a small change in a whole-file reformat.