### PR TITLE
ci(release): build release images per component, without a layer cache

### DIFF
--- a/.github/workflows/publish-github-releases.yml
+++ b/.github/workflows/publish-github-releases.yml
@@ -14,8 +14,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      components: ${{ steps.plan.outputs.components }}
-      repo: ${{ steps.plan.outputs.repo }}
+      released: ${{ steps.releases.outputs.released }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -27,6 +26,8 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # Also emits the build plan for the images job: one entry per component
+      # whose version changed in this release.
       - name: Create GitHub releases
         id: releases
         run: node ./scripts/release/create-releases.mjs "$BASE_SHA" "$HEAD_SHA"
@@ -36,47 +37,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha }}
 
-      # Each released component is published as its own image tagged with its own
-      # version, mirroring the per-component GitHub releases created above. Only
-      # components whose version changed in this release are built. Emitting the
-      # build inputs as data keeps the build job itself component-agnostic.
-      - name: Plan the image builds
-        id: plan
-        run: |
-          repo=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
-          components=$(node -e '
-            const dirs = { frontend: "frontend", api: "api", "mmr-api": "mmr-api" };
-            const contexts = {
-              frontend: "./frontend",
-              api: "./api/MMRProject.Api",
-              "mmr-api": "./mmr-api",
-            };
-            const planned = JSON.parse(process.env.RELEASED).map((name) => {
-              const version = require(`./${dirs[name]}/package.json`).version;
-              return {
-                name,
-                version,
-                context: contexts[name],
-                // Only mmr-api stamps its version into the binary at build time.
-                buildArgs: name === "mmr-api" ? `VERSION=${version}` : "",
-              };
-            });
-            console.log(JSON.stringify(planned));
-          ')
-          {
-            echo "components=$components"
-            echo "repo=$repo"
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          RELEASED: ${{ steps.releases.outputs.released }}
-
-  # One job per released component. A component that fails to build no longer
-  # stops the others from being published, and re-running failed jobs retries
-  # only that component instead of rebuilding everything.
+  # One job per released component, so a build failure no longer stops the other
+  # components from publishing and a re-run retries only the one that broke.
   images:
     needs: release
-    if: needs.release.outputs.components != '[]'
+    if: needs.release.outputs.released != '' && needs.release.outputs.released != '[]'
+    name: ${{ matrix.component.name }} image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -84,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: ${{ fromJson(needs.release.outputs.components) }}
+        component: ${{ fromJson(needs.release.outputs.released) }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -103,11 +69,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # No layer cache: the `type=gha` exporter never once wrote an entry here,
-      # so `cache-from` had nothing to restore while the failed export took the
-      # whole release down with it. This workflow runs every few weeks and cache
-      # entries expire after seven days, so a working cache would be cold anyway.
-      - name: Build and push ${{ matrix.component.name }}
+      - name: Resolve the image repository
+        id: image
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      # No layer cache: the gha exporter never wrote an entry for this repo, and
+      # its failure killed releases whose image had already pushed.
+      - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.component.context }}
@@ -115,5 +83,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: ${{ matrix.component.buildArgs }}
           tags: |
-            ghcr.io/${{ needs.release.outputs.repo }}/${{ matrix.component.name }}:${{ matrix.component.version }}
-            ghcr.io/${{ needs.release.outputs.repo }}/${{ matrix.component.name }}:latest
+            ghcr.io/${{ steps.image.outputs.repo }}/${{ matrix.component.name }}:${{ matrix.component.version }}
+            ghcr.io/${{ steps.image.outputs.repo }}/${{ matrix.component.name }}:latest

--- a/.github/workflows/publish-github-releases.yml
+++ b/.github/workflows/publish-github-releases.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      # Also emits the build plan for the images job: one entry per component
-      # whose version changed in this release.
       - name: Create GitHub releases
         id: releases
         run: node ./scripts/release/create-releases.mjs "$BASE_SHA" "$HEAD_SHA"
@@ -44,6 +42,9 @@ jobs:
     if: needs.release.outputs.released != '' && needs.release.outputs.released != '[]'
     name: ${{ matrix.component.name }} image
     runs-on: ubuntu-latest
+    # Emulated arm64 builds can wedge, and fail-fast: false means a stuck leg
+    # never cancels its siblings — three legs at the 6h default is 18h burnt.
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -69,10 +70,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve the image repository
-        id: image
-        run: echo "repo=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-
       # No layer cache: the gha exporter never wrote an entry for this repo, and
       # its failure killed releases whose image had already pushed.
       - name: Build and push
@@ -83,5 +80,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: ${{ matrix.component.buildArgs }}
           tags: |
-            ghcr.io/${{ steps.image.outputs.repo }}/${{ matrix.component.name }}:${{ matrix.component.version }}
-            ghcr.io/${{ steps.image.outputs.repo }}/${{ matrix.component.name }}:latest
+            ${{ matrix.component.image }}:${{ matrix.component.version }}
+            ${{ matrix.component.image }}:latest

--- a/.github/workflows/publish-github-releases.yml
+++ b/.github/workflows/publish-github-releases.yml
@@ -7,14 +7,15 @@ on:
     types:
       - closed
 
-permissions:
-  contents: write
-  packages: write
-
 jobs:
-  publish:
+  release:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'changeset-release/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      components: ${{ steps.plan.outputs.components }}
+      repo: ${{ steps.plan.outputs.repo }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -37,73 +38,82 @@ jobs:
 
       # Each released component is published as its own image tagged with its own
       # version, mirroring the per-component GitHub releases created above. Only
-      # components whose version changed in this release are built.
-      - name: Read component versions
-        id: versions
-        if: steps.releases.outputs.released != '[]'
+      # components whose version changed in this release are built. Emitting the
+      # build inputs as data keeps the build job itself component-agnostic.
+      - name: Plan the image builds
+        id: plan
         run: |
+          repo=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          components=$(node -e '
+            const dirs = { frontend: "frontend", api: "api", "mmr-api": "mmr-api" };
+            const contexts = {
+              frontend: "./frontend",
+              api: "./api/MMRProject.Api",
+              "mmr-api": "./mmr-api",
+            };
+            const planned = JSON.parse(process.env.RELEASED).map((name) => {
+              const version = require(`./${dirs[name]}/package.json`).version;
+              return {
+                name,
+                version,
+                context: contexts[name],
+                // Only mmr-api stamps its version into the binary at build time.
+                buildArgs: name === "mmr-api" ? `VERSION=${version}` : "",
+              };
+            });
+            console.log(JSON.stringify(planned));
+          ')
           {
-            echo "frontend=$(node -p "require('./frontend/package.json').version")"
-            echo "api=$(node -p "require('./api/package.json').version")"
-            echo "mmr_api=$(node -p "require('./mmr-api/package.json').version")"
-            echo "repo=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+            echo "components=$components"
+            echo "repo=$repo"
           } >> "$GITHUB_OUTPUT"
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASED: ${{ steps.releases.outputs.released }}
+
+  # One job per released component. A component that fails to build no longer
+  # stops the others from being published, and re-running failed jobs retries
+  # only that component instead of rebuilding everything.
+  images:
+    needs: release
+    if: needs.release.outputs.components != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        component: ${{ fromJson(needs.release.outputs.components) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up QEMU
-        if: steps.releases.outputs.released != '[]'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        if: steps.releases.outputs.released != '[]'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        if: steps.releases.outputs.released != '[]'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push frontend
-        if: contains(fromJson(steps.releases.outputs.released || '[]'), 'frontend')
+      # No layer cache: the `type=gha` exporter never once wrote an entry here,
+      # so `cache-from` had nothing to restore while the failed export took the
+      # whole release down with it. This workflow runs every few weeks and cache
+      # entries expire after seven days, so a working cache would be cold anyway.
+      - name: Build and push ${{ matrix.component.name }}
         uses: docker/build-push-action@v7
         with:
-          context: ./frontend
+          context: ${{ matrix.component.context }}
           push: true
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,mode=max,scope=frontend
+          build-args: ${{ matrix.component.buildArgs }}
           tags: |
-            ghcr.io/${{ steps.versions.outputs.repo }}/frontend:${{ steps.versions.outputs.frontend }}
-            ghcr.io/${{ steps.versions.outputs.repo }}/frontend:latest
-
-      - name: Build and push api
-        if: contains(fromJson(steps.releases.outputs.released || '[]'), 'api')
-        uses: docker/build-push-action@v7
-        with:
-          context: ./api/MMRProject.Api
-          push: true
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=api
-          cache-to: type=gha,mode=max,scope=api
-          tags: |
-            ghcr.io/${{ steps.versions.outputs.repo }}/api:${{ steps.versions.outputs.api }}
-            ghcr.io/${{ steps.versions.outputs.repo }}/api:latest
-
-      - name: Build and push mmr-api
-        if: contains(fromJson(steps.releases.outputs.released || '[]'), 'mmr-api')
-        uses: docker/build-push-action@v7
-        with:
-          context: ./mmr-api
-          push: true
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=mmr-api
-          cache-to: type=gha,mode=max,scope=mmr-api
-          build-args: |
-            VERSION=${{ steps.versions.outputs.mmr_api }}
-          tags: |
-            ghcr.io/${{ steps.versions.outputs.repo }}/mmr-api:${{ steps.versions.outputs.mmr_api }}
-            ghcr.io/${{ steps.versions.outputs.repo }}/mmr-api:latest
+            ghcr.io/${{ needs.release.outputs.repo }}/${{ matrix.component.name }}:${{ matrix.component.version }}
+            ghcr.io/${{ needs.release.outputs.repo }}/${{ matrix.component.name }}:latest

--- a/scripts/release/components.mjs
+++ b/scripts/release/components.mjs
@@ -1,5 +1,5 @@
 export const components = [
-  { name: "frontend", packageJsonPath: "frontend/package.json", changelogPath: "frontend/CHANGELOG.md" },
-  { name: "api", packageJsonPath: "api/package.json", changelogPath: "api/CHANGELOG.md" },
-  { name: "mmr-api", packageJsonPath: "mmr-api/package.json", changelogPath: "mmr-api/CHANGELOG.md" }
+  { name: "frontend", packageJsonPath: "frontend/package.json", changelogPath: "frontend/CHANGELOG.md", imageContext: "./frontend" },
+  { name: "api", packageJsonPath: "api/package.json", changelogPath: "api/CHANGELOG.md", imageContext: "./api/MMRProject.Api" },
+  { name: "mmr-api", packageJsonPath: "mmr-api/package.json", changelogPath: "mmr-api/CHANGELOG.md", imageContext: "./mmr-api", versionBuildArg: true }
 ];

--- a/scripts/release/create-releases.mjs
+++ b/scripts/release/create-releases.mjs
@@ -6,6 +6,31 @@ import { fileURLToPath } from "node:url";
 import { collectChangedComponents } from "./releases.mjs";
 import { components } from "./components.mjs";
 
+// One entry per released component that ships a container image. A component
+// without `imageContext` is not containerized and is simply absent here — its
+// GitHub release is unaffected.
+export function buildImagePlan(changed, repository) {
+  const repo = repository.toLowerCase();
+
+  return changed.flatMap(({ name, version }) => {
+    const component = components.find((candidate) => candidate.name === name);
+
+    if (!component?.imageContext) {
+      return [];
+    }
+
+    return [
+      {
+        name,
+        version,
+        context: component.imageContext,
+        image: `ghcr.io/${repo}/${name}`,
+        buildArgs: component.versionBuildArg ? `VERSION=${version}` : ""
+      }
+    ];
+  });
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const [baseSha, headSha] = process.argv.slice(2);
 
@@ -26,25 +51,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // them to downstream steps (e.g. image builds) after a transient failure.
   const changed = collectChangedComponents(repoRoot, baseSha);
 
-  // The image build takes its whole plan from here, so the version it tags and
-  // the version released below are one value rather than two reads that could
-  // drift. Built before the first release is cut: a component missing its image
-  // metadata then fails while nothing has been published yet.
-  const released = changed.map(({ name, version }) => {
-    const component = components.find((candidate) => candidate.name === name);
-
-    if (!component?.imageContext) {
-      console.error(`Component ${name} is missing imageContext in components.mjs`);
-      process.exit(1);
-    }
-
-    return {
-      name,
-      version,
-      context: component.imageContext,
-      buildArgs: component.versionBuildArg ? `VERSION=${version}` : ""
-    };
-  });
+  // Built from the same versions the releases below are cut from, so the image
+  // tag and the release cannot drift apart.
+  const released = buildImagePlan(changed, process.env.GITHUB_REPOSITORY);
 
   for (const { name, version, notes } of changed) {
     const tag = `${name}@${version}`;

--- a/scripts/release/create-releases.mjs
+++ b/scripts/release/create-releases.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { collectChangedComponents } from "./releases.mjs";
+import { components } from "./components.mjs";
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const [baseSha, headSha] = process.argv.slice(2);
@@ -24,6 +25,26 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // whether the GitHub release already exists, so a workflow re-run still reports
   // them to downstream steps (e.g. image builds) after a transient failure.
   const changed = collectChangedComponents(repoRoot, baseSha);
+
+  // The image build takes its whole plan from here, so the version it tags and
+  // the version released below are one value rather than two reads that could
+  // drift. Built before the first release is cut: a component missing its image
+  // metadata then fails while nothing has been published yet.
+  const released = changed.map(({ name, version }) => {
+    const component = components.find((candidate) => candidate.name === name);
+
+    if (!component?.imageContext) {
+      console.error(`Component ${name} is missing imageContext in components.mjs`);
+      process.exit(1);
+    }
+
+    return {
+      name,
+      version,
+      context: component.imageContext,
+      buildArgs: component.versionBuildArg ? `VERSION=${version}` : ""
+    };
+  });
 
   for (const { name, version, notes } of changed) {
     const tag = `${name}@${version}`;
@@ -63,8 +84,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 
   if (process.env.GITHUB_OUTPUT) {
-    const releasedNames = changed.map(({ name }) => name);
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `released=${JSON.stringify(releasedNames)}\n`);
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `released=${JSON.stringify(released)}\n`);
   }
 
   function releaseExists(tag) {

--- a/scripts/release/create-releases.test.mjs
+++ b/scripts/release/create-releases.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildImagePlan } from "./create-releases.mjs";
+import { components } from "./components.mjs";
+
+describe("buildImagePlan", () => {
+  it("carries the released version straight into the image tag", () => {
+    const plan = buildImagePlan([{ name: "frontend", version: "1.6.0" }], "office-rivals/mmr-project");
+
+    assert.deepEqual(plan, [
+      {
+        name: "frontend",
+        version: "1.6.0",
+        context: "./frontend",
+        image: "ghcr.io/office-rivals/mmr-project/frontend",
+        buildArgs: ""
+      }
+    ]);
+  });
+
+  it("passes VERSION only to the component that consumes it", () => {
+    const plan = buildImagePlan(
+      [
+        { name: "frontend", version: "1.6.0" },
+        { name: "api", version: "1.5.0" },
+        { name: "mmr-api", version: "1.2.4" }
+      ],
+      "office-rivals/mmr-project"
+    );
+
+    assert.deepEqual(
+      plan.map(({ name, buildArgs }) => [name, buildArgs]),
+      [
+        ["frontend", ""],
+        ["api", ""],
+        ["mmr-api", "VERSION=1.2.4"]
+      ]
+    );
+  });
+
+  it("lowercases the repository, since ghcr rejects uppercase paths", () => {
+    const [entry] = buildImagePlan([{ name: "api", version: "1.5.0" }], "Office-Rivals/MMR-Project");
+
+    assert.equal(entry.image, "ghcr.io/office-rivals/mmr-project/api");
+  });
+
+  it("omits a component that ships no image without disturbing the others", () => {
+    const plan = buildImagePlan(
+      [
+        { name: "docs", version: "1.0.0" },
+        { name: "api", version: "1.5.0" }
+      ],
+      "office-rivals/mmr-project"
+    );
+
+    assert.deepEqual(plan.map(({ name }) => name), ["api"]);
+  });
+
+  it("returns nothing when no component changed", () => {
+    assert.deepEqual(buildImagePlan([], "office-rivals/mmr-project"), []);
+  });
+
+  it("gives every component that has an image build context a docker context", () => {
+    for (const component of components.filter(({ imageContext }) => imageContext)) {
+      const [entry] = buildImagePlan([{ name: component.name, version: "9.9.9" }], "o/r");
+      assert.equal(entry.context, component.imageContext, component.name);
+    }
+  });
+});


### PR DESCRIPTION
Two consecutive `Publish GitHub Releases` runs failed on the 1.6.0 / 1.5.0 / 1.2.4 release, both at the same place and both *after* the frontend image had already built and pushed:

```
#28 pushing manifest for ghcr.io/.../frontend:1.6.0 ... done
#28 DONE 13.7s
#30 ERROR: error writing layer blob: failed to reserve cache
```

## The cache was never doing anything

The Actions cache for this repo holds **52 entries totalling 1.96 GB** — about 20% of the 10 GB limit, so this is not a capacity problem. **None of those entries come from buildkit.** The `type=gha` exporter has never successfully written one, which means `cache-from` has never had anything to restore. Both runs took eight to nine minutes, consistent with a cold build each time.

Even a working cache would earn little here. This workflow only runs when a release PR merges — every few weeks — and Actions cache entries are evicted after seven days without access, so it would be cold at almost every release.

So the cache lines are removed rather than made non-fatal. There is nothing to preserve, and deleting them removes the failure mode outright.

## One failure should not cost two images

All three builds shared a single job in sequence, so the frontend failure skipped the `api` and `mmr-api` build steps entirely. That release published its three GitHub Releases and the frontend image, but left `api:1.5.0` and `mmr-api:1.2.4` unpublished — and re-running could not fix it, because the frontend step fails first every time.

They now run as a matrix, one job per released component, with `fail-fast: false`. A failure is contained to its own component, the three build in parallel instead of in series, and `gh run rerun --failed` retries only what broke.

## Also in here

- The release job emits the build inputs (`name`, `version`, `context`, `buildArgs`) as JSON, so the build job is component-agnostic and adding a fourth component is a data change.
- Each job now declares only the permissions it needs: `contents: write` to cut releases, `packages: write` to push images.

## Verification

- `yaml.safe_load` parses the workflow; both jobs and the matrix expression resolve.
- Ran the planning script against this branch for `["frontend","api","mmr-api"]`, `["api"]` and `[]`. It produces the right contexts and versions, passes `VERSION=` only to `mmr-api`, and returns `[]` when nothing released — which the `images` job guard turns into a skip.

Behaviour is otherwise unchanged: same contexts, same platforms, same tags, same `VERSION` build arg.

## Risk

This workflow only runs on a release-PR merge, so it cannot be exercised before then. If the matrix misbehaves, the GitHub Releases are already created by the earlier job and the images can be rebuilt by re-running the job.