### PR TITLE
ci(release): run the release script tests, and add an image rebuild path

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -33,9 +33,11 @@ jobs:
           RELEASE_TAG: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
         run: gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
 
+      # refs/tags/ explicitly: an unqualified ref resolves a branch of the same
+      # name ahead of the tag, which would deploy a branch as a released version.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
+          ref: refs/tags/${{ format('{0}@{1}', inputs.component, inputs.version) }}
 
       - name: Log in to Azure
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3

--- a/.github/workflows/rebuild-release-image.yml
+++ b/.github/workflows/rebuild-release-image.yml
@@ -27,28 +27,44 @@ jobs:
       contents: read
       packages: write
     steps:
+      # The version reaches a git ref, a docker tag list and GITHUB_OUTPUT
+      # lines, each of which would treat a comma or newline as a separator.
+      - name: Validate the version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must be MAJOR.MINOR.PATCH, got: $VERSION" >&2
+            exit 1
+          fi
+
       - name: Verify release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
         run: gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
 
+      # refs/tags/ explicitly: an unqualified ref lets a branch of the same name
+      # win over the tag, which would publish a branch as a released version.
       - name: Check out the released source
         uses: actions/checkout@v7
         with:
-          ref: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
+          ref: refs/tags/${{ format('{0}@{1}', inputs.component, inputs.version) }}
 
-      # From the default branch, not the tag: the tag predates this tooling, and
-      # the component table on main is the one that knows where images build from.
+      # The tag predates this tooling, so the component table has to come from
+      # the default branch — pinned, because a dispatch can name any ref.
       - name: Check out the release tooling
         uses: actions/checkout@v7
         with:
           path: .release-tooling
+          ref: ${{ github.event.repository.default_branch }}
 
+      # From the tooling checkout: the planner runs on the tooling's Node, not
+      # on whatever the released tag happened to pin.
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version-file: .nvmrc
+          node-version-file: .release-tooling/.nvmrc
 
       - name: Plan the build
         id: plan

--- a/.github/workflows/rebuild-release-image.yml
+++ b/.github/workflows/rebuild-release-image.yml
@@ -18,6 +18,21 @@ on:
         description: Released version to rebuild
         required: true
         type: string
+      tag_latest:
+        description: Also move `latest` — only when this is the newest release of the component
+        required: false
+        default: false
+        type: boolean
+      force:
+        description: Overwrite the image tag if it already exists
+        required: false
+        default: false
+        type: boolean
+
+# Two dispatches for one component would otherwise race for the same tag.
+concurrency:
+  group: rebuild-image-${{ inputs.component }}
+  cancel-in-progress: false
 
 jobs:
   rebuild:
@@ -87,9 +102,40 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Deliberately no `latest` tag: this rebuilds an arbitrary past release,
-      # and moving `latest` backwards would downgrade anyone running the
-      # documented compose file.
+      # An existing tag is a published, possibly deployed artifact. A rebuild is
+      # not byte-identical — base layers and unpinned dependencies drift — so
+      # replacing one has to be asked for.
+      - name: Refuse to overwrite an existing image
+        if: ${{ !inputs.force }}
+        env:
+          IMAGE: ${{ steps.plan.outputs.image }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
+            echo "$IMAGE:$VERSION already exists. Dispatch with force to replace it." >&2
+            exit 1
+          fi
+
+      # `latest` is opt-in per dispatch. Moving it backwards would downgrade
+      # anyone running the documented compose file, but the case this workflow
+      # exists for is the *newest* release failing — there `latest` is stale
+      # until a rebuild moves it, and nothing else ever will.
+      - name: Resolve the tags
+        id: tags
+        env:
+          IMAGE: ${{ steps.plan.outputs.image }}
+          TAG_LATEST: ${{ inputs.tag_latest }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "list<<TAGS"
+            echo "$IMAGE:$VERSION"
+            if [ "$TAG_LATEST" = "true" ]; then
+              echo "$IMAGE:latest"
+            fi
+            echo "TAGS"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
@@ -97,4 +143,4 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: ${{ steps.plan.outputs.buildArgs }}
-          tags: ${{ steps.plan.outputs.image }}:${{ inputs.version }}
+          tags: ${{ steps.tags.outputs.list }}

--- a/.github/workflows/rebuild-release-image.yml
+++ b/.github/workflows/rebuild-release-image.yml
@@ -1,0 +1,84 @@
+name: Rebuild Release Image
+
+# Recovery path for a release whose image build failed. The publish workflow
+# only runs on a release-PR merge, and re-running it replays the workflow file
+# from that older ref, so a fix on main cannot reach it.
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: Component to rebuild
+        required: true
+        type: choice
+        options:
+          - frontend
+          - api
+          - mmr-api
+      version:
+        description: Released version to rebuild
+        required: true
+        type: string
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Verify release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
+        run: gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+
+      - name: Check out the released source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ format('{0}@{1}', inputs.component, inputs.version) }}
+
+      # From the default branch, not the tag: the tag predates this tooling, and
+      # the component table on main is the one that knows where images build from.
+      - name: Check out the release tooling
+        uses: actions/checkout@v7
+        with:
+          path: .release-tooling
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Plan the build
+        id: plan
+        run: node ./.release-tooling/scripts/release/print-image-plan.mjs "$COMPONENT" "$VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          COMPONENT: ${{ inputs.component }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Deliberately no `latest` tag: this rebuilds an arbitrary past release,
+      # and moving `latest` backwards would downgrade anyone running the
+      # documented compose file.
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ steps.plan.outputs.context }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: ${{ steps.plan.outputs.buildArgs }}
+          tags: ${{ steps.plan.outputs.image }}:${{ inputs.version }}

--- a/.github/workflows/test-release-scripts.yml
+++ b/.github/workflows/test-release-scripts.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - scripts/release/**
       - .nvmrc
+      - .github/workflows/test-release-scripts.yml
 
 jobs:
   test:

--- a/.github/workflows/test-release-scripts.yml
+++ b/.github/workflows/test-release-scripts.yml
@@ -1,0 +1,33 @@
+name: Release scripts - test
+
+# The release scripts own version bumps, changelog generation and the image
+# build plan, and their test suite was never wired into CI.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - scripts/release/**
+      - .nvmrc
+      - .github/workflows/test-release-scripts.yml
+  push:
+    branches:
+      - main
+    paths:
+      - scripts/release/**
+      - .nvmrc
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Run tests
+        run: node --test scripts/release/*.test.mjs

--- a/.github/workflows/test-release-scripts.yml
+++ b/.github/workflows/test-release-scripts.yml
@@ -21,6 +21,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 

--- a/scripts/release/create-releases.mjs
+++ b/scripts/release/create-releases.mjs
@@ -13,6 +13,12 @@ export function buildImagePlan(changed, repository) {
   const repo = repository.toLowerCase();
 
   return changed.flatMap(({ name, version }) => {
+    // A version reaches a docker tag list and GITHUB_OUTPUT lines, both of
+    // which split on separators. Guarded here so every caller inherits it.
+    if (!/^\d+\.\d+\.\d+$/.test(version)) {
+      throw new Error(`Version must be MAJOR.MINOR.PATCH, got: ${JSON.stringify(version)}`);
+    }
+
     const component = components.find((candidate) => candidate.name === name);
 
     if (!component?.imageContext) {

--- a/scripts/release/create-releases.test.mjs
+++ b/scripts/release/create-releases.test.mjs
@@ -56,14 +56,14 @@ describe("buildImagePlan", () => {
     assert.deepEqual(plan.map(({ name }) => name), ["api"]);
   });
 
-  it("keeps a separator-bearing version out of the tag it would split", () => {
-    // buildImagePlan itself does not validate — print-image-plan.mjs and the
-    // workflow do — so this pins where such a version would land if it slipped
-    // through, making the guards' necessity visible rather than implied.
-    const [entry] = buildImagePlan([{ name: "api", version: "1.5.0,evil" }], "o/r");
-
-    assert.equal(entry.image, "ghcr.io/o/r/api");
-    assert.equal(entry.version, "1.5.0,evil");
+  it("rejects a version carrying a tag-list or output separator", () => {
+    for (const version of ["1.5.0,evil", "1.5.0\nimage=evil", "1.5.0 ", "v1.5.0", "1.5"]) {
+      assert.throws(
+        () => buildImagePlan([{ name: "api", version }], "o/r"),
+        /MAJOR\.MINOR\.PATCH/,
+        version
+      );
+    }
   });
 
   it("returns nothing when no component changed", () => {

--- a/scripts/release/create-releases.test.mjs
+++ b/scripts/release/create-releases.test.mjs
@@ -56,6 +56,16 @@ describe("buildImagePlan", () => {
     assert.deepEqual(plan.map(({ name }) => name), ["api"]);
   });
 
+  it("keeps a separator-bearing version out of the tag it would split", () => {
+    // buildImagePlan itself does not validate — print-image-plan.mjs and the
+    // workflow do — so this pins where such a version would land if it slipped
+    // through, making the guards' necessity visible rather than implied.
+    const [entry] = buildImagePlan([{ name: "api", version: "1.5.0,evil" }], "o/r");
+
+    assert.equal(entry.image, "ghcr.io/o/r/api");
+    assert.equal(entry.version, "1.5.0,evil");
+  });
+
   it("returns nothing when no component changed", () => {
     assert.deepEqual(buildImagePlan([], "office-rivals/mmr-project"), []);
   });

--- a/scripts/release/print-image-plan.mjs
+++ b/scripts/release/print-image-plan.mjs
@@ -10,19 +10,19 @@ if (!name || !version) {
   process.exit(1);
 }
 
-// These values are printed as `key=value` lines and end up in a docker tag
-// list, so anything with a separator in it must not get that far.
-if (!/^\d+\.\d+\.\d+$/.test(version)) {
-  console.error(`Version must be MAJOR.MINOR.PATCH, got: ${JSON.stringify(version)}`);
-  process.exit(1);
-}
-
 if (!process.env.GITHUB_REPOSITORY) {
   console.error("Error: GITHUB_REPOSITORY environment variable is required");
   process.exit(1);
 }
 
-const [entry] = buildImagePlan([{ name, version }], process.env.GITHUB_REPOSITORY);
+let entry;
+
+try {
+  [entry] = buildImagePlan([{ name, version }], process.env.GITHUB_REPOSITORY);
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
 
 if (!entry) {
   console.error(`Component ${name} publishes no container image`);

--- a/scripts/release/print-image-plan.mjs
+++ b/scripts/release/print-image-plan.mjs
@@ -1,0 +1,27 @@
+// Prints one component's image build inputs as GITHUB_OUTPUT lines, so a
+// workflow rebuilding a single release image reads the same component table the
+// release itself is built from.
+import { buildImagePlan } from "./create-releases.mjs";
+
+const [name, version] = process.argv.slice(2);
+
+if (!name || !version) {
+  console.error("Usage: node ./scripts/release/print-image-plan.mjs <component> <version>");
+  process.exit(1);
+}
+
+if (!process.env.GITHUB_REPOSITORY) {
+  console.error("Error: GITHUB_REPOSITORY environment variable is required");
+  process.exit(1);
+}
+
+const [entry] = buildImagePlan([{ name, version }], process.env.GITHUB_REPOSITORY);
+
+if (!entry) {
+  console.error(`Component ${name} publishes no container image`);
+  process.exit(1);
+}
+
+console.log(`context=${entry.context}`);
+console.log(`image=${entry.image}`);
+console.log(`buildArgs=${entry.buildArgs}`);

--- a/scripts/release/print-image-plan.mjs
+++ b/scripts/release/print-image-plan.mjs
@@ -10,6 +10,13 @@ if (!name || !version) {
   process.exit(1);
 }
 
+// These values are printed as `key=value` lines and end up in a docker tag
+// list, so anything with a separator in it must not get that far.
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error(`Version must be MAJOR.MINOR.PATCH, got: ${JSON.stringify(version)}`);
+  process.exit(1);
+}
+
 if (!process.env.GITHUB_REPOSITORY) {
   console.error("Error: GITHUB_REPOSITORY environment variable is required");
   process.exit(1);


### PR DESCRIPTION
Two release-tooling gaps this week exposed.

## The release script tests never ran

`scripts/release/` owns version bumps, changelog generation and the image build plan. It has 51 tests across five `*.test.mjs` files — and `node --test` appears in no workflow, so none of them have ever run in CI. `test-release-scripts.yml` runs them on pull requests and pushes touching `scripts/release/`.

I found this while trying to rely on a test to guard a mistake in #391. It would have guarded nothing.

## A failed image build had no recovery path

The 1.6.0 / 1.5.0 / 1.2.4 release failed twice at the frontend layer-cache export, after the frontend image had already pushed. Because all three builds shared one job, `api` and `mmr-api` never built. Those two components have GitHub Releases and no container images today.

#391 stops that happening again, but it cannot repair what already happened: re-running the publish workflow replays the workflow file **from the release PR's ref**, not from `main`, so the fix on main never reaches that run. A third re-run would fail at the same step.

`Rebuild Release Image` is the missing path — a `workflow_dispatch` taking a component and a released version:

- Verifies the release tag exists before doing anything, matching `deploy-release.yml`.
- Checks out the released source at the tag, but reads the build plan from the default branch. The tag predates the tooling, so `print-image-plan.mjs` does not exist there.
- Reuses `buildImagePlan` from #391, so the context, image reference and `VERSION` build arg come from `components.mjs` rather than being restated in YAML.
- **Does not push `latest`.** Rebuilding an arbitrary past release must not move a mutable tag backwards — `README.md` tells self-hosters to run the whole stack off `:latest`. Both reviewers on #391 flagged that rollback as a live risk, and a rebuild path is precisely where it would bite.

## Verification

- 51/51 tests pass.
- `print-image-plan.mjs` exercised directly for `api 1.5.0` and `mmr-api 1.2.4` (correct context, lowercased image reference, `VERSION=` only for mmr-api), plus both failure paths: an unknown/imageless component and missing arguments each exit 1 with a clear message.
- Confirmed `api/MMRProject.Api/Dockerfile` and `mmr-api/Dockerfile` both exist at tags `api@1.5.0` and `mmr-api@1.2.4`, and that `.nvmrc` is present there for `setup-node`.
- Both workflows parse; checked for stray non-ASCII after an editing slip.

Once this merges I intend to dispatch it for `api 1.5.0` and `mmr-api 1.2.4` to fill the two missing images.